### PR TITLE
#select_list should return selected option text instead of value

### DIFF
--- a/features/select_list.feature
+++ b/features/select_list.feature
@@ -8,12 +8,12 @@ Feature: Select List
 
   Scenario: Selecting an element on the select list
     When I select "Test 2" from the select list
-    Then the current item should be "option2"
+    Then the current item should be "Test 2"
 
   Scenario Outline: Locating select lists on the Page
     When I search for the select list by "<search_by>"
     Then I should be able to select "Test 2"
-    And the value for the selected item should be "option2"
+    And the value for the selected item should be "Test 2"
 
   Scenarios:
     | search_by |
@@ -26,7 +26,7 @@ Feature: Select List
   Scenario Outline: Locating a select list using multiple parameters
     When I search for the select list by "<param1>" and "<param2>"
     Then I should be able to select "Test 2"
-    And the value for the selected item should be "option2"
+    And the value for the selected item should be "Test 2"
 
   Scenarios:
     | param1 | param2 |

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -172,7 +172,7 @@ module PageObject
 
     #
     # adds four methods - one to select an item in a drop-down,
-    # another to fetch the currently selected item, another
+    # another to fetch the currently selected item text, another
     # to retrieve the select list element, and another to check the 
     # drop down's existence.
     #

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -266,7 +266,9 @@ module PageObject
         #
         def select_list_value_for(identifier)
           process_selenium_call(identifier, Elements::SelectList, 'select') do |how, what|
-            @browser.find_element(how, what).attribute('value')
+            @browser.find_element(how, what).find_elements(:tag_name => 'option').each do |o|
+              return o.text if o.selected?
+            end
           end
         end
 

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -256,8 +256,8 @@ module PageObject
         # See PageObject::Accessors#select_list
         #
         def select_list_value_for(identifier)
-          process_watir_call("select_list(identifier).value", Elements::SelectList,
-                             identifier)
+          process_watir_call("select_list(identifier).options.each { |o| return o.text if o.selected? }",
+                             Elements::SelectList, identifier)
         end
 
         #


### PR DESCRIPTION
References https://github.com/cheezy/page-object/issues/51

Initial implementation of using selected option text instead of value.

@cheezy Can you help me with specs? I'm not strong with mocking and that's why this PR lacks updates to specs.
