### PR TITLE
Update #clear_cookies for Watir-WebDriver

### DIFF
--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -154,7 +154,7 @@ module PageObject
         # See PageObject#clear_cookies
         #
         def clear_cookies
-          @browser.clear_cookies
+          @browser.cookies.clear
         end
 
         #


### PR DESCRIPTION
It's now deprecated
https://github.com/watir/watir-webdriver/commit/4e81dd03592848b866f40a2474998fe2bbea5180
