### PR TITLE
Sends deprecation warnings to stderr

### DIFF
--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -89,12 +89,12 @@ module PageObject
       # delegate calls to driver element
       def method_missing(*args, &block)
         m = args.shift
-        puts "*** DEPRECATION WARNING"
-        puts "*** You are calling a method named #{m} at #{caller[0]}."
-        puts "*** This method does not exist in page-object so it is being passed to the driver."
-        puts "*** This feature will be removed in the near future."
-        puts "*** Please change your code to call the correct page-object method."
-        puts "*** If you are using functionality that does not exist in page-object please request it be added."
+        $stderr.puts "*** DEPRECATION WARNING"
+        $stderr.puts "*** You are calling a method named #{m} at #{caller[0]}."
+        $stderr.puts "*** This method does not exist in page-object so it is being passed to the driver."
+        $stderr.puts "*** This feature will be removed in the near future."
+        $stderr.puts "*** Please change your code to call the correct page-object method."
+        $stderr.puts "*** If you are using functionality that does not exist in page-object please request it be added."
         begin
           element.send m, *args, &block
         rescue Exception => e


### PR DESCRIPTION
This ensures that JSON and HTML command line output from cucumber can still be redirected and parsed separately from warnings and notices.
