### PR TITLE
Returned Rubinius and Ree to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 1.9.3
   - rbx-19mode
   - ree
-  - ruby-head
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Sorry for one more PR, I just checked and page-object features pass on Rubinius and Ree, so I returned them to Travis configuration.

Still, `ruby-head` is still failing. I don't know how to fix this. See http://travis-ci.org/#!/p0deje/page-object/jobs/1345389 for more details.
