### PR TITLE
New if_page function

### DIFF
--- a/lib/page-object/page_factory.rb
+++ b/lib/page-object/page_factory.rb
@@ -62,6 +62,18 @@ module PageObject
 
     # Support 'on' for readability of usage
     alias_method :on, :on_page
+    
+    #
+    # Create a page object if and only if the current page is the same page to be created
+    #
+    # @param [PageObject]  a class that has included the PageObject module
+    # @param [block]  an optional block to be called
+    # @return [PageObject] the newly created page object
+    #
+    def if_page(page_class, &block)
+      return @current_page unless @current_page.class == page_class
+      on_page(page_class, false, &block)
+    end
 
     #
     # Navigate to a specific page following a predefined path.


### PR DESCRIPTION
I’ve really enjoyed using the page-object and factory gems. I have a common scenario in which I wanted to use a step definition for multiple pages, especially when the feature set in the page is re-used template code. However, lets say the ids for the pages are slightly different. Therefore I often found myself doing this:

``` ruby
When /^I save the form$/ do
   on_page(NewProduct).save if @current_page.class == NewProduct
   on_page(EditProduct).update if @current_page.class == EditProduct
end
```

Adding an if_page adds a number of new, clean step definitions

``` ruby
When /^I save the form$/ do
   if_page NewProduct do |page|
      page.save
   end
   if_page EditProduct do |page|
      page.update
   end
end
```

Please provide me some input as to why it is accepted/declined.
Thanks!
