### PR TITLE
Improve finding table rows/columns by text.

### DIFF
--- a/features/table.feature
+++ b/features/table.feature
@@ -26,13 +26,29 @@ Feature: Table
     And the data for the first row should be "Data1" and "Data2"
     And the data for the last row should be "Data3" and "Data4"
     
-  Scenario: Retrieve data from a table using the row header
+  Scenario: Retrieve data from a table using a row header
     When I retrieve a table element
     Then the data for row "Data3" should be "Data3" and "Data4"
+
+  Scenario: Retrieve data from a table using a partial row header
+    When I retrieve a table element
+    Then the data for row "ata3" should be "Data3" and "Data4"
+
+  Scenario: Retrieve data from a table using a row header in the 2nd column
+    When I retrieve a table element
+    Then the data for row "Data4" should be "Data3" and "Data4"
+
+  Scenario: Retrieve data from a table using a partial row header in the 2nd column
+    When I retrieve a table element
+    Then the data for row "ata4" should be "Data3" and "Data4"
     
   Scenario: Retrieve data from a table using a column header
     When I retrieve a table element
     Then the data for column "Data2" and row "2" should be "Data4"
+
+  Scenario: Retrieve data from a table using a partial column header
+    When I retrieve a table element
+    Then the data for column "ata2" and row "2" should be "Data4"
     
   Scenario: Retrieve data from a table using both headers
     When I retrieve a table element

--- a/lib/page-object/platforms/selenium_webdriver/table.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table.rb
@@ -6,7 +6,7 @@ module PageObject
         #
         # Return the PageObject::Elements::TableRow for the index provided.  Index
         # is zero based.  If the index provided is a String then it
-        # will be matched with the text from the first column.
+        # will be matched with the text from any column. The text can be a substring of the full column text.
         #
         # @return [PageObject::Elements::TableRow]
         #
@@ -37,7 +37,7 @@ module PageObject
         def find_index_by_title(row_title, eles)
           eles.find_index do |row|
             columns = row.find_elements(:xpath, ".//child::td|th")
-            columns.first.text == row_title
+            columns.any? { |col| col.text.include? row_title }
           end
         end
 

--- a/lib/page-object/platforms/selenium_webdriver/table_row.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table_row.rb
@@ -8,6 +8,7 @@ module PageObject
         # Return the PageObject::Elements::TableCell for the index provided.  Index
         # is zero based.  If the index provided is a String then it
         # will be matched with the text from the columns in the first row.
+        # The text can be a substring of the full column text.
         #
         def [](idx)
           els = table_cells
@@ -28,7 +29,7 @@ module PageObject
         def find_index_by_title(title)
           table = parent
           table = table.parent if parent.element.tag_name == 'tbody'
-          table[0].find_index {|column| column.text == title}
+          table[0].find_index { |column| column.text.include? title }
         end
 
         def table_cells

--- a/lib/page-object/platforms/watir_webdriver/table.rb
+++ b/lib/page-object/platforms/watir_webdriver/table.rb
@@ -7,7 +7,7 @@ module PageObject
         #
         # Return the PageObject::Elements::TableRow for the index provided.  Index
         # is zero based.  If the index provided is a String then it
-        # will be matched with the text from the first column.
+        # will be matched with the text from any column. The text can be a substring of the full column text.
         #
         # @return [PageObject::Elements::TableRow]
         #
@@ -27,7 +27,9 @@ module PageObject
         private
 
         def find_index_by_title(row_title)
-          element.rows.find_index {|row| row[0].text == row_title}
+          element.rows.find_index do |row|
+            row.cells.any? { |col| col.text.include? row_title }
+          end
         end
 
       end

--- a/lib/page-object/platforms/watir_webdriver/table_row.rb
+++ b/lib/page-object/platforms/watir_webdriver/table_row.rb
@@ -7,6 +7,7 @@ module PageObject
         # Return the PageObject::Elements::TableCell for the index provided.  Index
         # is zero based.  If the index provided is a String then it
         # will be matched with the text from the columns in the first row.
+        # The text can be a substring of the full column text.
         #
         def [](idx)
           idx = find_index_by_title(idx) if idx.kind_of?(String)
@@ -26,7 +27,7 @@ module PageObject
         def find_index_by_title(title)
           table = element.parent
           first_row = table[0]
-          first_row.cells.find_index {|column| column.text == title}
+          first_row.cells.find_index {|column| column.text.include? title }
         end
 
       end


### PR DESCRIPTION
Allow finding of a row in the table by text by looking at any column that has that text.
Change above behavior to allow partial matching of text. (e.g. Looking for text "foo" will find a row that has a cell with text "foobar".)
Improve finding column for row by looking at column header to allow partial matching. (e.g. Looking for "foo" will find column with header "foobar".)
