### PR TITLE
Better support for table_row.find_index_by_title when tables have theads...

### DIFF
--- a/features/html/static_elements.html
+++ b/features/html/static_elements.html
@@ -78,6 +78,25 @@
         </tr>
     </table>
 
+    <table id='table_with_thead_id' border='1'>
+      <thead>
+        <tr>
+          <th>Col1</th>
+          <th>Col2</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Data1</td>
+          <td>Data2</td>
+        </tr>
+        <tr>
+          <td>Data3</td>
+          <td>Data4</td>
+        </tr>
+      </tbody>
+    </table>
+
     <form method="get" action="success.html">
         <input id='button_id' name='button_name' class='button_class' type="submit" value="Click Me"/>
         <input id='button_image_id' type='image' src='images/submit.gif' alt='Submit'/>

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -30,6 +30,10 @@ When /^I retrieve a table element$/ do
   @element = @page.table_id_element
 end
 
+When /^I retrieve a table with thead element$/ do
+  @element = @page.table_with_thead_id_element
+end
+
 When /^I retrieve a button element$/ do
   @element = @page.button_id_element
 end

--- a/features/support/page.rb
+++ b/features/support/page.rb
@@ -116,6 +116,7 @@ class Page
   table(:table_xpath, :xpath => '//table')
   table(:table_class_index, :class => "table_class", :index => 0)
   table(:table_name_index, :name => "table_name", :index => 0)
+  table(:table_with_thead_id, :id => 'table_with_thead_id')
 
   cell(:cell_id, :id => 'cell_id')
   cell(:cell_name, :name => 'cell_name')

--- a/features/table.feature
+++ b/features/table.feature
@@ -46,6 +46,14 @@ Feature: Table
     When I retrieve a table element
     Then the data for column "Data2" and row "2" should be "Data4"
 
+  Scenario: Retrieve data from a table with a thead using a column header
+    When I retrieve a table with thead element
+    Then the data for column "Col1" and row "2" should be "Data1"
+
+  Scenario: Retrieve data from the first row of a table with a thead using a column header
+    When I retrieve a table with thead element
+    Then the data for column "Col1" and row "1" should be "Col1"
+
   Scenario: Retrieve data from a table using a partial column header
     When I retrieve a table element
     Then the data for column "ata2" and row "2" should be "Data4"

--- a/lib/page-object/platforms/selenium_webdriver/table_row.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table_row.rb
@@ -28,7 +28,8 @@ module PageObject
 
         def find_index_by_title(title)
           table = parent
-          table = table.parent if parent.element.tag_name == 'tbody'
+          parent_tag_name = parent.element.tag_name
+          table = table.parent if (parent_tag_name == 'tbody' || parent_tag_name == 'thead')
           table[0].find_index { |column| column.text.include? title }
         end
 

--- a/lib/page-object/platforms/watir_webdriver/table_row.rb
+++ b/lib/page-object/platforms/watir_webdriver/table_row.rb
@@ -26,6 +26,7 @@ module PageObject
 
         def find_index_by_title(title)
           table = element.parent
+          table = table.parent if table.tag_name == 'tbody'
           first_row = table[0]
           first_row.cells.find_index {|column| column.text.include? title }
         end


### PR DESCRIPTION
... and tbodys.

In Watir, if the row we're looking at is in a tbody, we need to go up one level before finding the first row in the table.
For Selenium, if the row we're looking at is in a thead, accessing the 0th element of the thead gets nil. We have to go up one level to the table so [0] will return a row.

The test case for the selenium bug may look weird (why would you try to access the cell with column header "Col1" in the header row itself?). However, we hit it while iterating over the rows in the table and looking at all cells with column header "Col1".
