### PR TITLE
Add support for javascript alerts/confirms that reload page.

### DIFF
--- a/features/html/static_elements.html
+++ b/features/html/static_elements.html
@@ -128,7 +128,9 @@
     <a href="success.html">Hello</a>
 
     <input id=alert_button type=button onclick="alert('I am an alert')" value=Alert>
+    <input id=alert_button_that_reloads type=button onclick="alert('I am an alert'); location.reload()" value="Alert that Reloads">
     <input id=confirm_button type=button onclick="this.value = confirm('set the value')" value=Confirm>
+    <input id=confirm_button_that_reloads type=button onclick="if(confirm('set the value')) location.reload()" value="Confirm that Reloads">
     <input id=prompt_button type=button onclick='this.value = prompt("enter your name", "John Doe")' value=Prompt>
 
     <h1 id="h1_id" class="h1_class" name="h1_name">h1's are cool</h1>

--- a/features/page_level_actions.feature
+++ b/features/page_level_actions.feature
@@ -31,8 +31,16 @@ Feature: Page level actions
     When I handle the alert
     Then I should be able to get the alert's message
 
+  Scenario: Handling alert popups that reload the page
+    When I handle the alert that reloads the page
+    Then I should be able to get the alert's message
+
   Scenario: Handling confirm popups
     When I handle the confirm
+    Then I should be able to get the confirm message
+
+  Scenario: Handling confirm popups that reload the page
+    When I handle the confirm that reloads the page
     Then I should be able to get the confirm message
 
   Scenario: Handling prompt popups

--- a/features/step_definitions/page_level_actions_steps.rb
+++ b/features/step_definitions/page_level_actions_steps.rb
@@ -23,6 +23,12 @@ When /^I handle the alert$/ do
   end
 end
 
+When /^I handle the alert that reloads the page$/ do
+  @msg = @page.alert do
+    @page.alert_button_that_reloads
+  end
+end
+
 Then /^I should be able to get the alert\'s message$/ do
   @msg.should == "I am an alert"
 end
@@ -30,6 +36,12 @@ end
 When /^I handle the confirm$/ do
   @msg = @page.confirm(true) do
     @page.confirm_button
+  end
+end
+
+When /^I handle the confirm that reloads the page$/ do
+  @msg = @page.confirm(true) do
+    @page.confirm_button_that_reloads
   end
 end
 

--- a/features/support/page.rb
+++ b/features/support/page.rb
@@ -255,7 +255,9 @@ class Page
   paragraph(:p_name_index, :name => 'p_name', :index => 0)
 
   button(:alert_button, :id => 'alert_button')
+  button(:alert_button_that_reloads, :id => 'alert_button_that_reloads')
   button(:confirm_button, :id => 'confirm_button')
+  button(:confirm_button_that_reloads, :id => 'confirm_button_that_reloads')
   button(:prompt_button, :id => 'prompt_button')
 
   file_field(:file_field_id, :id => 'file_field_id')

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -70,9 +70,11 @@ module PageObject
         # See PageObject#alert
         #
         def alert(frame=nil, &block)
-          @browser.execute_script "window.alert = function(msg) { window.__lastWatirAlert = msg; }"
           yield
-          @browser.execute_script "return window.__lastWatirAlert"
+          alert = @browser.switch_to.alert
+          value = alert.text
+          alert.accept
+          value
         end
 
         #
@@ -80,9 +82,11 @@ module PageObject
         # See PageObject#confirm
         #
         def confirm(response, frame=nil, &block)
-          @browser.execute_script "window.confirm = function(msg) { window.__lastWatirConfirm = msg; return #{!!response} }"
           yield
-          @browser.execute_script "return window.__lastWatirConfirm"
+          alert = @browser.switch_to.alert
+          value = alert.text
+          response ? alert.accept : alert.dismiss
+          value
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -71,9 +71,9 @@ module PageObject
         #
         def alert(frame=nil, &block)
           switch_to_frame(frame)
-          @browser.wd.execute_script "window.alert = function(msg) { window.__lastWatirAlert = msg; }"
           yield
-          value = @browser.wd.execute_script "return window.__lastWatirAlert"
+          value = @browser.alert.text
+          @browser.alert.ok
           switch_to_default_content(frame)
           value
         end
@@ -84,9 +84,9 @@ module PageObject
         #
         def confirm(response, frame=nil, &block)
           switch_to_frame(frame)
-          @browser.wd.execute_script "window.confirm = function(msg) { window.__lastWatirConfirm = msg; return #{!!response} }"
           yield
-          value = @browser.wd.execute_script "return window.__lastWatirConfirm"
+          value = @browser.alert.text
+          response ? @browser.alert.ok : @browser.alert.close
           switch_to_default_content(frame)
           value
         end


### PR DESCRIPTION
The existing functionality overrode window.alert and window.confirm in
order to save the alert/confirm message on the window object. However,
if the alert/confirm did a location.reload(), the message would be lost.
Instead of overriding these functions, use the built in alert/confirm
functionality of Watir and Selenium to save the alert message in a ruby
variable.
