### PR TITLE
Add support for possible javascript popups

### DIFF
--- a/features/page_level_actions.feature
+++ b/features/page_level_actions.feature
@@ -31,6 +31,10 @@ Feature: Page level actions
     When I handle the alert
     Then I should be able to get the alert's message
 
+  Scenario: Handling possible alert popups
+    When I handle the possible alert
+    Then I should be able to verify the popup didn't have a message
+
   Scenario: Handling alert popups that reload the page
     When I handle the alert that reloads the page
     Then I should be able to get the alert's message
@@ -39,6 +43,10 @@ Feature: Page level actions
     When I handle the confirm
     Then I should be able to get the confirm message
 
+  Scenario: Handling possible confirm popups
+    When I handle the possible confirm
+    Then I should be able to verify the popup didn't have a message
+
   Scenario: Handling confirm popups that reload the page
     When I handle the confirm that reloads the page
     Then I should be able to get the confirm message
@@ -46,6 +54,10 @@ Feature: Page level actions
   Scenario: Handling prompt popups
     When I handle the prompt
     Then I should be able to get the message and default value
+
+  Scenario: Handling possible prompt popups
+    When I handle the possible prompt
+    Then I should be able to verify the popup didn't have a message
     
   Scenario: Attach to window using title
     When I open a second window

--- a/features/step_definitions/page_level_actions_steps.rb
+++ b/features/step_definitions/page_level_actions_steps.rb
@@ -23,6 +23,12 @@ When /^I handle the alert$/ do
   end
 end
 
+When /^I handle the possible alert$/ do
+  @msg = @page.alert do
+    @page.alert_button_element.focus
+  end
+end
+
 When /^I handle the alert that reloads the page$/ do
   @msg = @page.alert do
     @page.alert_button_that_reloads
@@ -33,9 +39,19 @@ Then /^I should be able to get the alert\'s message$/ do
   @msg.should == "I am an alert"
 end
 
+Then /^I should be able to verify the popup didn\'t have a message$/ do
+  @msg.should be_nil
+end
+
 When /^I handle the confirm$/ do
   @msg = @page.confirm(true) do
     @page.confirm_button
+  end
+end
+
+When /^I handle the possible confirm$/ do
+  @msg = @page.confirm(true) do
+    @page.confirm_button_element.focus
   end
 end
 
@@ -52,6 +68,12 @@ end
 When /^I handle the prompt$/ do
   @msg = @page.prompt("Cheezy") do
     @page.prompt_button
+  end
+end
+
+When /^I handle the possible prompt$/ do
+  @msg = @page.prompt("Cheezy") do
+    @page.prompt_button_element.focus
   end
 end
 

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -71,9 +71,12 @@ module PageObject
         #
         def alert(frame=nil, &block)
           yield
-          alert = @browser.switch_to.alert
-          value = alert.text
-          alert.accept
+          begin
+            alert = @browser.switch_to.alert
+            value = alert.text
+            alert.accept
+          rescue Selenium::WebDriver::Error::NoAlertPresentError
+          end
           value
         end
 
@@ -83,9 +86,12 @@ module PageObject
         #
         def confirm(response, frame=nil, &block)
           yield
-          alert = @browser.switch_to.alert
-          value = alert.text
-          response ? alert.accept : alert.dismiss
+          begin
+            alert = @browser.switch_to.alert
+            value = alert.text
+            response ? alert.accept : alert.dismiss
+          rescue Selenium::WebDriver::Error::NoAlertPresentError
+          end
           value
         end
 

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -72,8 +72,11 @@ module PageObject
         def alert(frame=nil, &block)
           switch_to_frame(frame)
           yield
-          value = @browser.alert.text
-          @browser.alert.ok
+          value = nil
+          if @browser.alert.exists?
+            value = @browser.alert.text
+            @browser.alert.ok
+          end
           switch_to_default_content(frame)
           value
         end
@@ -85,8 +88,11 @@ module PageObject
         def confirm(response, frame=nil, &block)
           switch_to_frame(frame)
           yield
-          value = @browser.alert.text
-          response ? @browser.alert.ok : @browser.alert.close
+          value = nil
+          if @browser.alert.exists?
+            value = @browser.alert.text
+            response ? @browser.alert.ok : @browser.alert.close
+          end
           switch_to_default_content(frame)
           value
         end


### PR DESCRIPTION
Prior to switching to the alert/confirm functionality built-in to Watir and Selenium alert and confirm could be used on actions that didn't necessarily cause the popups to appear. Now errors are raised from the Watir and Selenium methods when there is no alert or confirm present.
