### PR TITLE
Return nil when there is no corresponding table cell for a referenced column.

### DIFF
--- a/features/html/static_elements.html
+++ b/features/html/static_elements.html
@@ -100,6 +100,9 @@
           <td>Data3</td>
           <td>Data4</td>
         </tr>
+        <tr>
+          <td>Data5</td>
+        </tr>
       </tbody>
     </table>
 

--- a/features/table.feature
+++ b/features/table.feature
@@ -70,6 +70,10 @@ Feature: Table
     When I retrieve a table element
     Then the data for row "Data3" and column "Data20" should be nil
 
+  Scenario: Retrieve data from a table that does not have a cell which corresponds to a column header
+    When I retrieve a table with thead element
+    Then the data for row "Data5" and column "Col2" should be nil
+
   Scenario Outline: Locating table cells on the Page
     When I retrieve a table element by "<search_by>"
     Then the data for row "1" should be "Data1" and "Data2"

--- a/lib/page-object/platforms/selenium_webdriver/table_row.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table_row.rb
@@ -13,7 +13,7 @@ module PageObject
         def [](idx)
           els = table_cells
           idx = find_index_by_title(idx) if idx.kind_of?(String)
-          return nil unless idx
+          return nil unless idx  && columns >= idx + 1
           Object::PageObject::Elements::TableCell.new(els[idx], :platform => :selenium_webdriver)
         end
 

--- a/lib/page-object/platforms/watir_webdriver/table_row.rb
+++ b/lib/page-object/platforms/watir_webdriver/table_row.rb
@@ -11,7 +11,7 @@ module PageObject
         #
         def [](idx)
           idx = find_index_by_title(idx) if idx.kind_of?(String)
-          return nil unless idx
+          return nil unless idx && columns >= idx + 1
           Object::PageObject::Elements::TableCell.new(element[idx], :platform => :watir_webdriver)
         end
 

--- a/spec/page-object/elements/table_row_spec.rb
+++ b/spec/page-object/elements/table_row_spec.rb
@@ -14,6 +14,7 @@ describe PageObject::Elements::TableRow do
     context "for selenium" do
       it "should return a table cell when indexed" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :selenium_webdriver)
+        table_row.stub(:columns).and_return(2)
         table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_cell)
         table_cell.should_receive(:[]).and_return(table_cell)
         table_row[0].should be_instance_of PageObject::Elements::TableCell
@@ -43,6 +44,7 @@ describe PageObject::Elements::TableRow do
 
       it "should return a table cell when indexed" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :watir_webdriver)
+        table_row.stub(:columns).and_return(2)
         table_row_driver.should_receive(:[]).with(1).and_return(table_cell)
         table_row[1].should be_instance_of PageObject::Elements::TableCell
       end


### PR DESCRIPTION
When indexing a table by column for a table cell, currently TableRow
will return a TableCell object even if there is not a cell which
corresponds to the referenced column.  This commit will cause the
TableRow#[] method to return nil if a cell doesn't exist for the
referenced column.
