### PR TITLE
Make attach_to_window work with partial urls in selenium.

### DIFF
--- a/features/html/failure.html
+++ b/features/html/failure.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>Failure</title>
+</head>
+<body>
+<h1>Failure</h1>
+</body>
+</html>

--- a/features/html/static_elements.html
+++ b/features/html/static_elements.html
@@ -150,6 +150,7 @@
     <h6 id="h6_id" class="h6_class" name="h6_name">h6's are cool</h6>
 
     <a href="success.html" target="_blank">New Window</a>
+    <a href="failure.html" target="_blank">Another New Window</a>
 
     <input type="text" id="onfocus_text_field" onfocus="document.getElementById('onfocus_test').innerHTML = 'changed by onfocus event'"/>
     <div id="onfocus_test"></div>

--- a/features/page_level_actions.feature
+++ b/features/page_level_actions.feature
@@ -62,9 +62,19 @@ Feature: Page level actions
   Scenario: Attach to window using title
     When I open a second window
     Then I should be able to attach to a page object using title
+
+  Scenario: Attach to window using title with multiple windows
+    When I open a second window
+    When I open a third window
+    Then I should be able to attach to a page object using title
     
   Scenario: Attach to window using url
     When I open a second window
+    Then I should be able to attach to a page object using url
+
+  Scenario: Attach to window using url with multiple windows
+    When I open a second window
+    When I open a third window
     Then I should be able to attach to a page object using url
     
   Scenario: Refreshing the page

--- a/features/step_definitions/page_level_actions_steps.rb
+++ b/features/step_definitions/page_level_actions_steps.rb
@@ -86,6 +86,10 @@ When /^I open a second window$/ do
   @page.open_window
 end
 
+When /^I open a third window$/ do
+  @page.open_another_window
+end
+
 class SecondPage
   include PageObject
 end
@@ -93,11 +97,13 @@ end
 Then /^I should be able to attach to a page object using title$/ do
   @second_page = SecondPage.new(@browser)
   @second_page.attach_to_window(:title => "Success")
+  @second_page.title.should == "Success"
 end
 
 Then /^I should be able to attach to a page object using url$/ do
   @second_page = SecondPage.new(@browser)
   @second_page.attach_to_window(:url => "success.html")
+  @second_page.current_url.should include 'success.html'
 end
 
 Then /^I should be able to refresh the page$/ do

--- a/features/support/page.rb
+++ b/features/support/page.rb
@@ -281,6 +281,7 @@ class Page
   label(:label_name_index, :name => "label_name", :index => 0)
 
   link(:open_window, :text => 'New Window')
+  link(:open_another_window, :text => 'Another New Window')
   link(:child, :id => 'child')
 
   area(:area_id, :id => 'area')

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -126,7 +126,7 @@ module PageObject
           handles.each do |handle|
             @browser.switch_to.window handle
             if (key == :title and value == @browser.title) or
-              (key == :url and value == @browser.current_url)
+              (key == :url and @browser.current_url.include?(value))
               return @browser.switch_to.window handle, &block
             end
           end


### PR DESCRIPTION
The attach_to_window RDoc claims partial urls should work, but they don't
  work in Selenium since there is a == check instead of a .include?.
- Add assertion to the attach to window then steps to verify that the
  attach generated an expected result.
- Add test to expose functionality. With the existing logic, selenium
  would iterate through all the existing handles until it found a full
  match on the url. The existing attach_to_window test wasn't hitting the
  full match, but the last handle switched to was the one looked for, so
  existing test passed by accident.
- Change selenium's attach_to_window implementation to use .include?.
