### PR TITLE
Update element.rb to not emit deprecation message

### DIFF
--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -84,17 +84,19 @@ module PageObject
           return how, what
         end
       end
-      
+
       # @private
       # delegate calls to driver element
       def method_missing(*args, &block)
         m = args.shift
-        $stderr.puts "*** DEPRECATION WARNING"
-        $stderr.puts "*** You are calling a method named #{m} at #{caller[0]}."
-        $stderr.puts "*** This method does not exist in page-object so it is being passed to the driver."
-        $stderr.puts "*** This feature will be removed in the near future."
-        $stderr.puts "*** Please change your code to call the correct page-object method."
-        $stderr.puts "*** If you are using functionality that does not exist in page-object please request it be added."
+        unless (m == :wait_until_present || m == :wait_while_present || m == :when_present)
+          $stderr.puts "*** DEPRECATION WARNING"
+          $stderr.puts "*** You are calling a method named #{m} at #{caller[0]}."
+          $stderr.puts "*** This method does not exist in page-object so it is being passed to the driver."
+          $stderr.puts "*** This feature will be removed in the near future."
+          $stderr.puts "*** Please change your code to call the correct page-object method."
+          $stderr.puts "*** If you are using functionality that does not exist in page-object please request it be added."
+        end
         begin
           element.send m, *args, &block
         rescue Exception => e


### PR DESCRIPTION
see: https://github.com/cheezy/page-object/issues/138

The thing I don't like about this approach is when watir comes up with new methods/change method names, we would have to change it as well. 

What do you think?
