### PR TITLE
Resolved double_click issue for Selenium

### DIFF
--- a/features/element.feature
+++ b/features/element.feature
@@ -285,3 +285,8 @@ Feature: Elements
   Scenario: Getting an element's id
     When I retrieve a button element
     Then I should know its id is "button_id"
+
+  Scenario: Double Clicking
+    Given I am on the Double Click page
+    When I double click the button
+    Then the paragraph should read "Double Click Received"

--- a/features/html/double_click.html
+++ b/features/html/double_click.html
@@ -1,0 +1,13 @@
+<html>
+    <body>
+        <button ondblclick="change_text()">Double Click</button>
+        <p id="change_on_double_click">The double click has not occurred.</p>
+    </body>
+
+<script>
+    function change_text()
+    {
+      document.getElementById("change_on_double_click").innerHTML="Double Click Received"
+    }
+</script>
+</html>

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -212,3 +212,22 @@ end
 Then /^I should know its id is "([^\"]*)"$/ do |id|
   @element.id.should == id
 end
+
+class DoubleClickPage
+  include PageObject
+  button(:click)
+  paragraph(:text)
+end
+
+Given /^I am on the Double Click page$/ do
+  @page = DoubleClickPage.new(@browser)
+  @page.navigate_to UrlHelper.double_click
+end
+
+When /^I double click the button$/ do
+  @page.click_element.double_click
+end
+
+Then /^the paragraph should read "([^"]*)"$/ do |expected_text|
+  @page.text.should == expected_text
+end

--- a/features/support/url_helper.rb
+++ b/features/support/url_helper.rb
@@ -8,7 +8,6 @@ module UrlHelper
       "file://#{html}"
     end
 
-
     def static_elements
       "#{files}/static_elements.html"
     end
@@ -47,6 +46,10 @@ module UrlHelper
 
     def hover
       "#{files}/hover.html"
+    end
+
+    def double_click
+      "#{files}/double_click.html"
     end
   end
 end

--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -25,12 +25,7 @@ module PageObject
         element.click
       end
 
-      #
-      # double click the element
-      #
-      def double_click
-        element.double_click
-      end
+
 
       #
       # return true if the element is enabled

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -121,6 +121,14 @@ module PageObject
         end
 
         #
+        # hover over the element
+        #
+        def double_click
+          mouse = Selenium::WebDriver::Mouse.new(bridge)
+          mouse.double_click(element)
+        end
+
+        #
         # find the parent element
         #
         def parent

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -110,6 +110,13 @@ module PageObject
         end
 
         #
+        # double click the element
+        #
+        def double_click
+          element.double_click
+        end
+
+        #
         # find the parent element
         #
         def parent


### PR DESCRIPTION
Cheezy,

I have removed double_click from PageObject::Elements::Element and added it it to Watir and Selenium platform elements to use Selenium::WebDriver::Mouse.double_click(element) when running in the selenium driver.

I also added a Scenario to the Element feature to test this functionality.  Adding a new html page was required to support this test
