### PR TITLE
moving table_row and table_cell initializers from platform modules to element classes

### DIFF
--- a/lib/page-object/elements/table.rb
+++ b/lib/page-object/elements/table.rb
@@ -44,6 +44,11 @@ module PageObject
         ".//child::tr"
       end
 
+      def initialize_row(row_element, platform)
+        Object::PageObject::Elements::TableRow.new(row_element, platform)
+      end
+
+
       def include_platform_for platform
         super
         if platform[:platform] == :watir_webdriver

--- a/lib/page-object/elements/table_row.rb
+++ b/lib/page-object/elements/table_row.rb
@@ -26,6 +26,11 @@ module PageObject
         ".//child::td|th"
       end
 
+      def initialize_cell(row_element, platform)
+        Object::PageObject::Elements::TableCell.new(row_element, platform)
+      end
+
+
       def include_platform_for platform
         super
         if platform[:platform] == :watir_webdriver

--- a/lib/page-object/platforms/selenium_webdriver/table.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table.rb
@@ -14,7 +14,7 @@ module PageObject
           eles = table_rows
           idx = find_index_by_title(idx, eles) if idx.kind_of?(String)
           return nil unless idx
-          Object::PageObject::Elements::TableRow.new(eles[idx], :platform => :selenium_webdriver)
+          initialize_row(eles[idx], :platform => :selenium_webdriver)
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/table_row.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table_row.rb
@@ -14,7 +14,7 @@ module PageObject
           els = table_cells
           idx = find_index_by_title(idx) if idx.kind_of?(String)
           return nil unless idx  && columns >= idx + 1
-          Object::PageObject::Elements::TableCell.new(els[idx], :platform => :selenium_webdriver)
+          initialize_cell(els[idx], :platform => :selenium_webdriver)
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/table.rb
+++ b/lib/page-object/platforms/watir_webdriver/table.rb
@@ -14,7 +14,7 @@ module PageObject
         def [](idx)
           idx = find_index_by_title(idx) if idx.kind_of?(String)
           return nil unless idx
-          Object::PageObject::Elements::TableRow.new(element[idx], :platform => :watir_webdriver)
+          initialize_row(element[idx], :platform => :watir_webdriver)
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/table_row.rb
+++ b/lib/page-object/platforms/watir_webdriver/table_row.rb
@@ -12,7 +12,7 @@ module PageObject
         def [](idx)
           idx = find_index_by_title(idx) if idx.kind_of?(String)
           return nil unless idx && columns >= idx + 1
-          Object::PageObject::Elements::TableCell.new(element[idx], :platform => :watir_webdriver)
+          initialize_cell(element[idx], :platform => :watir_webdriver)
         end
 
         #


### PR DESCRIPTION
I've added and initialize row method to the table, and an initialize
Cell method to the table_row.  This simplifies extension of the table
class by pulling initialization of rows and cells out of the platform
modules, allowing extension of the Row or Cell class to be used more
easily.
