### PR TITLE
Avoid using return in block

### DIFF
--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -277,7 +277,7 @@ module PageObject
         # See PageObject::Accessors#select_list
         #
         def select_list_value_for(identifier)
-          process_watir_call("select_list(identifier).options.each {|o| return o.text if o.selected?}",
+          process_watir_call("select_list(identifier).options.find {|o| o.selected?}.text",
                              Elements::SelectList, identifier)
         end
 


### PR DESCRIPTION
This has been driving me nuts all day, it seems like the return in 

``` ruby
   select_list(identifier).options.each {|o| return o.text if o.selected?}
```

Is causing jruby-1.7.2 to exit.  Like my cucumber run just stops, no error, nothing to rescue.  Running the code outside an instance_eval call results in the same behavior.  

``` ruby
  options = @browser.select_list(identifier).options
  options.each {|o| return o.text if o.selected? }
```

Running an equivalent block without the return leaves jruby running.

This is Win 7 Pro, JRuby 1.7.2, using IE9.

Can't reproduce on Mac Lion, MRI, Firefox.  No idea how to write a test for this.
