### PR TITLE
Find elements with no locator

### DIFF
--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -1199,7 +1199,7 @@ module PageObject
         define_method("#{name}_elements") do
           return call_block(&block) unless block.nil?
           platform_method = (method_name == :checkboxes) ? 'checkboxs_for' : "#{method_name.to_s}_for"
-          platform.send platform_method, identifier.first.clone
+          platform.send platform_method, (identifier.first ? identifier.first.clone : {})
         end
       end
     end


### PR DESCRIPTION
Currently the following page object will throw error:

``` ruby
class Page
  include PageObject

  spans :test
end

page = Page.new
page.test_elements
#=> lib/page-object/accessors.rb:1202:in `clone': can't clone NilClass (TypeError)
```

Quick fix for this. Sorry, I haven't found a good place to add spec, but can easily do it if you point me to correct file.
