### PR TITLE
Fix travis CI image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # page-object
 
-[![Build Status](http://travis-ci.org/cheezy/page-object.png)](http://travis-ci.org/cheezy/page-object)
+[![Build Status](https://travis-ci.org/cheezy/page-object.png)](https://travis-ci.org/cheezy/page-object)
 
 
 A simple gem that assists in creating flexible page objects for testing browser based applications. The goal is to facilitate creating abstraction layers in your tests to decouple the tests from the item they are testing and to provide a simple interface to the elements on a page. It works with both watir-webdriver and selenium-webdriver.


### PR DESCRIPTION
The travis CI image isn't displaying for me on github in the page-object README.md, looks like it has been switched to https.
