### PR TITLE
Change Rubydoc.info link to gem page instead of master branch page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple gem that assists in creating flexible page objects for testing browser 
 
 The project [wiki](https://github.com/cheezy/page-object/wiki/page-object) is the first place to go to learn about how to use page-object.
 
-The rdocs for this project can be found at [rubydoc.info](http://rubydoc.info/github/cheezy/page-object/master/frames).
+The rdocs for this project can be found at [rubydoc.info](http://rubydoc.info/gems/page-object/framess).
 
 To see the changes from release to release please look at the [ChangeLog](https://raw.github.com/cheezy/page-object/master/ChangeLog)
 


### PR DESCRIPTION
I believe most people want to read about features available in the latest released stable version, not master branch
