### PR TITLE
block parameter changes for ruby 1.8.7

### DIFF
--- a/lib/page-object/widgets.rb
+++ b/lib/page-object/widgets.rb
@@ -29,7 +29,11 @@ module PageObject
 
     def self.define_accessors(base, widget_tag, widget_class)
       accessors_module = Module.new do
-        define_method widget_tag do |name, identifier={:index => 0}, &block|
+        define_method widget_tag do |name, *identifier_args, &block|
+          
+          identifier = identifier_args.first
+          identifier = {:index => 0} if identifier == nil
+          
           define_method("#{name}_element") do
             return call_block(&block) if block
             platform.send("#{widget_tag}_for", identifier.clone)


### PR DESCRIPTION
Hi, 

I was having problems on ruby 1.8.7 with lib/page-object/widgets.rb.  So I changed the default block parameter to make 1.8.7 work as well as 1.9.3. (Extending 1.8.7 support at least for a bit longer)  

Ran tests on both 1.9.3 and 1.8.7. All passed. 

Is 1.8.7 still officially supported? Let me know what you think.

Thanks
