### PR TITLE
Allow arguments for execute_script

### DIFF
--- a/features/javascript.feature
+++ b/features/javascript.feature
@@ -16,3 +16,13 @@ Feature: Handling javascript events
     Given I am on the static elements page
     Given I execute the javascript "return 2 + 2;"
     Then I should get the answer "4"
+
+  Scenario: Executing javascript in the browser with value argument
+    Given I am on the static elements page
+    Given I execute the javascript "return 2 + Number(arguments[0]);" with an argument of "2"
+    Then I should get the answer "4"
+
+  Scenario: Executing javascript in the browser with element argument
+    Given I am on the static elements page
+    Given I execute the javascript "arguments[0].value = 'abcDEF';" with a text field argument
+    Then the text field should contain "abcDEF"

--- a/features/step_definitions/javascript_steps.rb
+++ b/features/step_definitions/javascript_steps.rb
@@ -39,6 +39,15 @@ Given /^I execute the javascript "([^\"]*)"$/ do |script|
   @answer = @page.execute_script script
 end
 
+Given /^I execute the javascript "([^\"]*)" with an argument of "([^\"]*)"$/ do |script, arg|
+  @answer = @page.execute_script script, arg
+end
+
+Given /^I execute the javascript "([^\"]*)" with a text field argument$/ do |script|
+  text_field = @page.text_field_element(:id => 'text_field_id')
+  @page.execute_script(script, text_field)
+end
+
 Then /^I should get the answer "([^\"]*)"$/ do |answer|
   @answer.should == answer.to_i
 end

--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -249,8 +249,14 @@ module PageObject
   #
   # Execute javascript on the browser
   #
-  def execute_script(script)
-    platform.execute_script(script)
+  # @example Get inner HTML of element
+  #   span = @page.span_element
+  #   @page.execute_script "return arguments[0].innerHTML", span
+  #   #=> "Span innerHTML"
+  #
+  def execute_script(script, *args)
+    args.map! { |e| e.kind_of?(PageObject::Elements::Element) ? e.element : e }
+    platform.execute_script(script, *args)    
   end
 
   #

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -111,8 +111,8 @@ module PageObject
         # platform method to execute javascript on the browser
         # See PageObject#execute_script
         #
-        def execute_script(script)
-          @browser.execute_script script
+        def execute_script(script, *args)
+          @browser.execute_script(script, *args)
         end
         
         #

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -115,8 +115,8 @@ module PageObject
         # platform method to execute javascript on the browser
         # See PageObject#execute_script
         #
-        def execute_script(script)
-          @browser.execute_script(script)
+        def execute_script(script, *args)
+          @browser.execute_script(script, *args)
         end
     
         #


### PR DESCRIPTION
Allow arguments, including elements, to be passed to execute_script for use in the script's arguments array.
