### PR TITLE
Watir select list options should use watir elements

### DIFF
--- a/lib/page-object/platforms/watir_webdriver/select_list.rb
+++ b/lib/page-object/platforms/watir_webdriver/select_list.rb
@@ -10,7 +10,7 @@ module PageObject
         # @return [PageObject::Elements::Option]
         #
         def [](idx)
-          Object::PageObject::Elements::Option.new(options[idx], :platform => :watir_webdriver)
+          options[idx]
         end
 
         #
@@ -34,12 +34,7 @@ module PageObject
         # @return [array of PageObject::Elements::Option]
         #
         def options
-          elements = []
-          options = element.wd.find_elements(:xpath, child_xpath)
-          options.each do |opt|
-            elements << Object::PageObject::Elements::Option.new(opt, :platform => :watir_webdriver)
-          end
-          elements
+          element.options.map { |e| ::PageObject::Elements::Option.new(e, :platform => :watir_webdriver) }
         end
 
         #
@@ -55,7 +50,6 @@ module PageObject
         def selected_values
           element.selected_options.map { |e| e.value }.compact
         end
-
 
         #
         # Returns true if the select list has one or more options where text or label matches the given value.


### PR DESCRIPTION
For Watir, the `PageObject::Elements::Options` returned by `SelectList#[]` and `SelectList#options` seem to be using the wrong underlying native element.

For example, for any page that has a select list, you can see that the underlying element of the select list is a Watir element (as expected):

``` ruby
p page.select_list_element.class
#=> PageObject::Elements::SelectList
p page.select_list_element.element.class
#=> Watir::Select
```

When you get select list's options using `options`, you can see that the underlying is a Selenium object (unexpected).

``` ruby
p page.select_list_element.options.first.class
#=> PageObject::Elements::Option
p page.select_list_element.options.first.element.class
#=> Selenium::WebDriver::Element
```

If instead you get an option using `[]`, you can see that the underlying object is a PageObject object, which has an underlying Selenium object (unexpected).

``` ruby
p page.select_list_element[0].class
#=> PageObject::Elements::Option
p page.select_list_element[0].element.class
#=> PageObject::Elements::Option
p page.select_list_element[0].element.element.class
#=> Selenium::WebDriver::Element
```

Presumably, the underlying options should be using a Watir object.

I assume these methods were already under test, so I did not add any new tests.
