### PR TITLE
Allow dynamically locating elements within iframes

### DIFF
--- a/features/frames.feature
+++ b/features/frames.feature
@@ -48,6 +48,11 @@ Feature: Handling frames
     When I type "page-object" into the text field from frame 1 identified dynamically
     Then I should verify "page-object" in the text field for frame 1 identified dynamically
 
+  Scenario: Identifying items in iframes at runtime
+    Given I am on the iframe elements page
+    When I type "page-object" into the text field from iframe 1 identified dynamically
+    Then I should verify "page-object" in the text field for iframe 1 identified dynamically
+
   Scenario: Handling alerts inside frames
     Given I am on the frame elements page
     When I trigger an alert within a frame

--- a/features/step_definitions/frames_steps.rb
+++ b/features/step_definitions/frames_steps.rb
@@ -119,6 +119,18 @@ Then /^I should verify "([^\"]*)" in the text field for frame 1 identified dynam
   end
 end
 
+When /^I type "([^\"]*)" into the text field from iframe 1 identified dynamically$/ do |value|
+  @page.in_iframe(:id => 'frame_one_1') do |frame|
+    @page.text_field_element(:name => 'senderElement', :frame => frame).value = value
+  end
+end
+
+Then /^I should verify "([^\"]*)" in the text field for iframe 1 identified dynamically$/ do |value|
+  @page.in_iframe(:id => 'frame_one_1') do |frame|
+    @page.text_field_element(:name => 'senderElement', :frame => frame).value.should == value
+  end
+end
+
 When /^I trigger an alert within a frame$/ do
   @page.in_frame(:id => 'frame_three_3') do |frame|
     @msg = @page.alert(frame) do

--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -260,7 +260,7 @@ module PageObject
   end
 
   #
-  # Identify an element as existing within a frame or iframe.  A frame parameter
+  # Identify an element as existing within a frame.  A frame parameter
   # is passed to the block and must be passed to the other calls to PageObject.
   # You can nest calls to in_frame by passing the frame to the next level.
   #
@@ -279,6 +279,28 @@ module PageObject
   #
   def in_frame(identifier, frame=nil, &block)
     platform.in_frame(identifier, frame, &block)
+  end
+
+  #
+  # Identify an element as existing within an iframe.  A frame parameter
+  # is passed to the block and must be passed to the other calls to PageObject.
+  # You can nest calls to in_iframe by passing the frame to the next level.
+  #
+  # @example
+  #   in_iframe(:id => 'iframe_id') do |iframe|
+  #     text_field_element(:id => 'ifname', :frame => iframe)
+  #   end
+  #
+  # @param [Hash] identifier how we find the iframe.  The valid keys are:
+  #   * :id => Watir and Selenium
+  #   * :index => Watir and Selenium
+  #   * :name => Watir and Selenium
+  #   * :class => Watir only
+  # @param frame passed from a previous call to in_iframe.  Used to nest calls
+  # @param block that contains the calls to elements that exist inside the iframe.
+  #
+  def in_iframe(identifier, frame=nil, &block)
+    platform.in_iframe(identifier, frame, &block)
   end
 
   #


### PR DESCRIPTION
When iframes were separated from frames, the ability to dynamically locate elements within an iframe was lost. The existing PageObject#in_frame method now only allows locating in frame elements.

Adding a PageObject#in_iframe method will bring back the dynamically locating of elements within iframes.
