### PR TITLE
Update WatirWebdriver::PageObject#nested_frames to support multiple identifiers

### DIFF
--- a/features/frames.feature
+++ b/features/frames.feature
@@ -11,10 +11,16 @@ Feature: Handling frames
     #And I should be able to get the text fields text from frame 2 using "index"
 
 @watir_only    
-  Scenario: Accessing elements withing the frame using Regexp
+  Scenario: Accessing elements within the frame using Regexp
     Given I am on the frame elements page
     When I type "page-object" into the text field for frame 2 using "regex"
     Then I should verify "page-object" is in the text field for frame 2 using "regex"
+
+@watir_only    
+  Scenario: Accessing elements within the frame using multiple identifiers
+    Given I am on the iframe elements page
+    When I type "page-object" into the text field for frame 2 using "multiple identifiers"
+    Then I should verify "page-object" is in the text field for frame 2 using "multiple identifiers"
 
   Scenario: Switching between frames
     Given I am on the frame elements page

--- a/features/step_definitions/frames_steps.rb
+++ b/features/step_definitions/frames_steps.rb
@@ -52,6 +52,9 @@ class IFramePage
     text_field(:text_field_1_index, :name => 'senderElement', :frame => frame)
   end
 
+  in_iframe(:class => 'iframe', :name => 'frame2') do |frame|
+    text_field(:text_field_2_multiple_identifiers, :name => 'recieverElement', :frame => frame)      
+  end
 end
 
 
@@ -66,11 +69,11 @@ Given /^I am on the iframe elements page$/ do
 end
 
 When /^I type "([^\"]*)" into the text field for frame 2 using "([^\"]*)"$/ do |text, arg_type|
-  @page.send "text_field_2_#{arg_type}=".to_sym, text
+  @page.send "text_field_2_#{arg_type.gsub(' ', '_')}=".to_sym, text
 end
 
 Then /^I should verify "([^\"]*)" is in the text field for frame 2 using "([^\"]*)"$/ do |text, arg_type|
-  result = @page.send "text_field_2_#{arg_type}".to_sym
+  result = @page.send "text_field_2_#{arg_type.gsub(' ', '_')}".to_sym
   result.should == text
 end
 
@@ -79,11 +82,11 @@ end
 #end
 
 When /^I type "([^\"]*)" into the text field from frame 1 using "([^\"]*)"$/ do |text, arg_type|
-  @page.send "text_field_1_#{arg_type}=".to_sym, text
+  @page.send "text_field_1_#{arg_type.gsub(' ', '_')}=".to_sym, text
 end
 
 Then /^I should verify "([^\"]*)" is in the text field for frame 1 using "([^\"]*)"$/ do |text, arg_type|
-  result = @page.send "text_field_1_#{arg_type}".to_sym
+  result = @page.send "text_field_1_#{arg_type.gsub(' ', '_')}".to_sym
   result.should == text
 end
 

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -974,24 +974,26 @@ module PageObject
           identifier[:tag_name] = tag if identifier[:name]
           identifier
         end
-    
+
         def nested_frames(frame_identifiers)
           return if frame_identifiers.nil?
           frame_str = ''
           frame_identifiers.each do |frame|
-            id = frame.values.first
             type = frame.keys.first
-            value = id.values.first
-            if value.is_a?(Regexp)
-              frame_str += "#{type.to_s}(:#{id.keys.first} => #{value.inspect})."
-            else
-              frame_str += "#{type.to_s}(:#{id.keys.first} => #{value})." if value.to_s.is_integer
-              frame_str += "#{type.to_s}(:#{id.keys.first} => '#{value}')." unless value.to_s.is_integer
-            end
+            identifier = frame.values.first.map do |key, value|
+              if value.is_a?(Regexp)
+                ":#{key} => #{value.inspect}"
+              elsif value.to_s.is_integer
+                ":#{key} => #{value}"
+              else
+                ":#{key} => '#{value}'"
+              end
+            end.join(', ')
+            frame_str += "#{type.to_s}(#{identifier})."
           end
           frame_str
         end
-        
+
         def switch_to_default_content(frame_identifiers)
           @browser.wd.switch_to.default_content unless frame_identifiers.nil?          
         end


### PR DESCRIPTION
Watir allows frames/iframes to be located using multiple identifiers. For example:

``` ruby
browser.iframe(:class => 'iframe', :name => 'frame2').exists?
```

While the page object allows multiple identifiers to be specified:

``` ruby
in_iframe(:class => 'iframe', :name => 'frame2') do |frame|
  text_field(:text_field_2_multiple_identifiers, :name => 'recieverElement', :frame => frame)      
end
```

It only uses the first identifier. When locating the above element, the #nested_frame method only returns "iframe(:class => 'iframe')." instead of "iframe(:class => 'iframe', :name => 'frame2').".
