### PR TITLE
Test for Issue #224

### DIFF
--- a/features/frames.feature
+++ b/features/frames.feature
@@ -53,6 +53,11 @@ Feature: Handling frames
     When I type "page-object" into the text field from iframe 1 identified dynamically
     Then I should verify "page-object" in the text field for iframe 1 identified dynamically
 
+  Scenario: Interacting with elements in an iframe
+    Given I am on the iframe elements page
+    When I retrieve a text field element within an iframe
+    Then I should be able to get the name of the text field element within an iframe
+
   Scenario: Handling alerts inside frames
     Given I am on the frame elements page
     When I trigger an alert within a frame

--- a/features/step_definitions/frames_steps.rb
+++ b/features/step_definitions/frames_steps.rb
@@ -154,3 +154,11 @@ When /^I trigger a prompt within a frame$/ do
     end
   end
 end
+
+When /^I retrieve a text field element within an iframe$/ do
+  @element = @page.text_field_2_id_element
+end
+
+Then /^I should be able to get the name of the text field element within an iframe$/ do
+  @element.attribute(:name).should == 'recieverElement'
+end


### PR DESCRIPTION
Test for Issue #224.

The test will pass when using the Watir-Webdriver platform. When using the Selenium-Webdriver platform, the reported "Element belongs to a different frame than the current one - switch to its containing frame to use it (Selenium::WebDriver::Error::StaleElementReferenceError)" exception occurs.