### PR TITLE
Correct typo in SelectList#options documentation

### DIFF
--- a/lib/page-object/platforms/selenium_webdriver/select_list.rb
+++ b/lib/page-object/platforms/selenium_webdriver/select_list.rb
@@ -34,7 +34,7 @@ module PageObject
         end
 
         #
-        # Return an array of Options contained in the select lit.
+        # Return an array of Options contained in the select list.
         #
         # @return [array of PageObject::Elements::Option]
         def options

--- a/lib/page-object/platforms/watir_webdriver/select_list.rb
+++ b/lib/page-object/platforms/watir_webdriver/select_list.rb
@@ -29,7 +29,7 @@ module PageObject
         end
 
         #
-        # Return an array of Options contained in the select lit.
+        # Return an array of Options contained in the select list.
         #
         # @return [array of PageObject::Elements::Option]
         #


### PR DESCRIPTION
The SelectList#options documentation says "Return an array of Options contained in the select lit." I believe "lit" should be "list".
