### PR TITLE
Remove methods for clearing radio buttons

### DIFF
--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -404,19 +404,18 @@ module PageObject
     end
 
     #
-    # adds five methods - one to select, another to clear,
-    # another to return if a radio button is selected,
-    # another method to return a PageObject::Elements::RadioButton
+    # adds four methods - one to select, another to return if a radio button 
+    # is selected, another method to return a PageObject::Elements::RadioButton
     # object representing the radio button element, and another to check
     # the radio button's existence.
     #
     # @example
     #   radio_button(:north, :id => "north")
-    #   # will generate 'select_north', 'clear_north', 'north_selected?',
+    #   # will generate 'select_north', 'north_selected?',
     #   # 'north_element', and 'north?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a radio button.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a radio button.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -433,10 +432,6 @@ module PageObject
       define_method("select_#{name}") do
         return platform.select_radio(identifier.clone) unless block_given?
         self.send("#{name}_element").select
-      end
-      define_method("clear_#{name}") do
-        return platform.clear_radio(identifier.clone) unless block_given?
-        self.send("#{name}_element").clear
       end
       define_method("#{name}_selected?") do
         return platform.radio_selected?(identifier.clone) unless block_given?

--- a/lib/page-object/page_populator.rb
+++ b/lib/page-object/page_populator.rb
@@ -51,7 +51,6 @@ module PageObject
 
     def populate_radiobutton(key, value)
       return self.send "select_#{key}" if value
-      return self.send "clear_#{key}"
     end
 
     def populate_radiobuttongroup(key, value)

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -426,16 +426,6 @@ module PageObject
         end
 
         #
-        # platform method to clear a radio button
-        # See PageObject::Accessors#radio_button
-        #
-        def clear_radio(identifier)
-          process_selenium_call(identifier, Elements::RadioButton, 'input', :type => 'radio') do |how, what|
-            @browser.find_element(how, what).click if @browser.find_element(how, what).selected?
-          end
-        end
-
-        #
         # platform method to determine if a radio button is selected
         # See PageObject::Accessors#radio_button
         #

--- a/lib/page-object/platforms/selenium_webdriver/radio_button.rb
+++ b/lib/page-object/platforms/selenium_webdriver/radio_button.rb
@@ -9,13 +9,6 @@ module PageObject
         def select
           element.click unless selected?
         end
-        
-        #
-        # clear the radiobutton
-        #
-        def clear
-          element.click if selected?
-        end
 
         #
         # return if it is selected

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -389,14 +389,6 @@ module PageObject
         end
 
         #
-        # platform method to clear a radio button
-        # See PageObject::Accessors#radio_button
-        #
-        def clear_radio(identifier)
-          process_watir_call("radio(identifier).clear", Elements::RadioButton, identifier)
-        end
-
-        #
         # platform method to determine if a radio button is selected
         # See PageObject::Accessors#radio_button
         #

--- a/lib/page-object/platforms/watir_webdriver/radio_button.rb
+++ b/lib/page-object/platforms/watir_webdriver/radio_button.rb
@@ -11,13 +11,6 @@ module PageObject
         end
 
         #
-        # clear the radiobutton
-        #
-        def clear
-          element.clear
-        end
-
-        #
         # return if it is selected
         #
         def selected?

--- a/spec/page-object/elements/selenium/radio_button_spec.rb
+++ b/spec/page-object/elements/selenium/radio_button_spec.rb
@@ -35,12 +35,6 @@ describe PageObject::Elements::RadioButton do
         radio_button.select
       end
       
-      it "should clear" do
-        selenium_rb.should_receive(:click)
-        selenium_rb.should_receive(:selected?).and_return(true)
-        radio_button.clear
-      end
-      
       it "should know if it is selected" do
         selenium_rb.should_receive(:selected?).and_return(true)
         radio_button.should be_selected

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -81,12 +81,6 @@ describe PageObject::PagePopulator  do
     page_object.populate_page_with('rb' => true)
   end
 
-  it "should clear a radio button when false is specified" do
-    page_object.should_receive(:clear_rb)
-    page_object.stub(:is_enabled?).and_return(true)
-    page_object.populate_page_with('rb' => false)
-  end
-
   it "should select the correct element from a radio button group" do
     page_object.should_receive(:select_rbg).with('blah')
     page_object.populate_page_with('rbg' => 'blah')

--- a/spec/page-object/selenium_accessors_spec.rb
+++ b/spec/page-object/selenium_accessors_spec.rb
@@ -290,13 +290,6 @@ describe PageObject::Accessors do
       selenium_page_object.select_first
     end
 
-    it "should clear a radio button" do
-      selenium_browser.should_receive(:find_element).twice.and_return(selenium_browser)
-      selenium_browser.should_receive(:selected?).and_return(true)
-      selenium_browser.should_receive(:click)
-      selenium_page_object.clear_first
-    end
-
     it "should determine if a radio is selected" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:selected?).and_return(true)

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -599,7 +599,6 @@ describe PageObject::Accessors do
     context "when called on a page object" do
       it "should generate accessor methods" do
         watir_page_object.should respond_to :select_first
-        watir_page_object.should respond_to :clear_first
         watir_page_object.should respond_to :first_selected?
         watir_page_object.should respond_to(:first_element)
       end
@@ -613,12 +612,6 @@ describe PageObject::Accessors do
       watir_browser.should_receive(:radio).and_return(watir_browser)
       watir_browser.should_receive(:set)
       watir_page_object.select_first
-    end
-
-    it "should clear a radio button" do
-      watir_browser.should_receive(:radio).and_return(watir_browser)
-      watir_browser.should_receive(:clear)
-      watir_page_object.clear_first
     end
 
     it "should determine if a radio is selected" do


### PR DESCRIPTION
Methods exist and are created to clear radio buttons. These methods do not appear to work as intended.

Given a page:

``` html
<html>
  <body>
    <input type="radio" name="group" value="A">A<br>
    <input type="radio" name="group" value="B">B
  </body>
</html>
```

And a page object:

``` ruby
class MyPage
  include PageObject

  radio(:my_radio, :value => 'B')
end
```

When using Selenium-WebDriver, clearing the radio button does not change the radio button's state:

``` ruby
page = MyPage.new(browser)
p page.my_radio_selected?
#=> false
page.select_my_radio
p page.my_radio_selected?
#=> true
page.clear_my_radio
p page.my_radio_selected?
#=> true
```

Watir-Webdriver removed the Radio#clear button several versions ago. As a result, trying to clear the radio button for a page object generates an exception:

``` ruby
page = MyPage.new(browser)
p page.my_radio_selected?
#=> false
page.select_my_radio
p page.my_radio_selected?
#=> true
page.clear_my_radio
p page.my_radio_selected?
#=> C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.0.2/lib/page-object/platforms/watir_webdriver/page_object.rb:960:in `instance_eval': undefined method `clear' for #<Watir::Radio:0x3677aa8> (NoMethodError)
#=>     from (eval):1:in `process_watir_call'
#=>     from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.0.2/lib/page-object/platforms/watir_webdriver/page_object.rb:960:in `instance_eval'
#=>     from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.0.2/lib/page-object/platforms/watir_webdriver/page_object.rb:960:in `process_watir_call'
#=>     from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.0.2/lib/page-object/platforms/watir_webdriver/page_object.rb:396:in `clear_radio'
#=>     from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.0.2/lib/page-object/accessors.rb:438:in `block in radio_button'
#=>     from pageobject.rb:30:in `<main>'
```

Given that the methods do not work as intended and a user cannot clear a radio button (without some sort of Javascript), this pull request suggests removing the methods.
