### PR TITLE
Correct typos in documentation

### DIFF
--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -196,7 +196,7 @@ module PageObject
   end
 
   #
-  # Override the normal alert popup so it does not occurr.
+  # Override the normal alert popup so it does not occur.
   #
   # @example
   #   message = @page.alert do
@@ -212,7 +212,7 @@ module PageObject
   end
 
   #
-  # Override the normal confirm popup so it does not occurr.
+  # Override the normal confirm popup so it does not occur.
   #
   # @example
   #   message = @popup.confirm(true) do
@@ -229,7 +229,7 @@ module PageObject
   end
 
   #
-  # Override the normal promp popup so it does not occurr.
+  # Override the normal prompt popup so it does not occur.
   #
   # @example
   #   message = @popup.prompt("Some Value") do
@@ -329,7 +329,7 @@ module PageObject
 
   #
   # Attach to a running window.  You can locate the window using either
-  # the window's title or url.  If it failes to connect to a window it will
+  # the window's title or url.  If it fails to connect to a window it will
   # pause for 1 second and try again.
   #
   # @example

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -13,7 +13,7 @@ module PageObject
   module Accessors
 
     #
-    # Set some values that can be used withing the class.  This is
+    # Set some values that can be used within the class.  This is
     # typically used to provide values that help build dynamic urls in
     # the page_url method
     #
@@ -195,7 +195,7 @@ module PageObject
     #   # 'first_name?' methods
     #
     # @param  [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a text field.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a text field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -231,7 +231,7 @@ module PageObject
     #   # will generate 'user_id', 'user_id_element' and 'user_id?' methods
     #
     # @param [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a hidden field.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a hidden field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -263,7 +263,7 @@ module PageObject
     #   # 'address?' methods
     #
     # @param  [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a text area.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a text area.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -299,7 +299,7 @@ module PageObject
     #   # will generate 'state', 'state=', 'state_element', 'state?', "state_options" methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a select list.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a select list.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -339,7 +339,7 @@ module PageObject
     #   # will generate 'add_to_cart', 'add_to_cart_element', and 'add_to_cart?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a link.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a link.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -375,7 +375,7 @@ module PageObject
     #   # 'active_element', and 'active?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a checkbox.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a checkbox.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -416,7 +416,7 @@ module PageObject
     #   # 'north_element', and 'north?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a radio button.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a radio button.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -448,7 +448,7 @@ module PageObject
     #
     # adds five methods to help interact with a radio button group -
     # a method to select a radio button in the group by given value/text,
-    # a method to return the values of all radio buttins in the group, a method
+    # a method to return the values of all radio buttons in the group, a method
     # to return if a radio button in the group is selected (will return
     # the text of the selected radio button, if true), a method to return
     # an array of PageObject::Elements::RadioButton objects representing
@@ -504,7 +504,7 @@ module PageObject
     #   # will generate 'purchase', 'purchase_element', and 'purchase?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a button.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a button.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -535,7 +535,7 @@ module PageObject
     #   # will generate 'message', 'message_element', and 'message?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a div.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a div.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -564,7 +564,7 @@ module PageObject
     #   # will generate 'alert', 'alert_element', and 'alert?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a span.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a span.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -595,7 +595,7 @@ module PageObject
     #   # will generate a 'cart', 'cart_element' and 'cart?' method
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a table.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a table.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -623,7 +623,7 @@ module PageObject
     #   # will generate 'total', 'total_element', and 'total?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a cell.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a cell.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -653,7 +653,7 @@ module PageObject
     #   # will generate 'logo_element' and 'logo?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an image.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an image.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :alt => Watir and Selenium
     #   * :class => Watir and Selenium
@@ -679,7 +679,7 @@ module PageObject
     #   # will generate 'login_element' and 'login?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a form.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a form.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :action => Watir and Selenium
     #   * :class => Watir and Selenium
@@ -703,7 +703,7 @@ module PageObject
     #   # will generate 'item_one', 'item_one_element', and 'item_one?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a list item.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a list item.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -724,7 +724,7 @@ module PageObject
     alias_method :li, :list_item
 
     #
-    # adds three methods - one to return the text within the unorderd
+    # adds three methods - one to return the text within the unordered
     # list, one to retrieve the unordered list element, and another to
     # check it's existence.
     #
@@ -733,7 +733,7 @@ module PageObject
     #   # will generate 'menu', 'menu_element' and 'menu?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an unordered list.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an unordered list.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -753,7 +753,7 @@ module PageObject
     alias_method :ul, :unordered_list
 
     #
-    # adds three methods - one to return the text withing the ordered
+    # adds three methods - one to return the text within the ordered
     # list, one to retrieve the ordered list element, and another to
     # test it's existence.
     #
@@ -762,7 +762,7 @@ module PageObject
     #   # will generate 'top_five', 'top_five_element' and 'top_five?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an ordered list.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an ordered list.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -790,7 +790,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H1.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a H1.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -817,7 +817,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H2.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a H2.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -844,7 +844,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H3.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a H3.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -871,7 +871,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H4.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a H4.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -898,7 +898,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H5.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a H5.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -925,7 +925,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H6.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a H6.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -952,7 +952,7 @@ module PageObject
     #   # will generate 'title', 'title_element', and 'title?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a paragraph.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a paragraph.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -980,7 +980,7 @@ module PageObject
     #   # will generate 'the_file=', 'the_file_element', and 'the_file?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a file_field.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a file_field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -1009,7 +1009,7 @@ module PageObject
     #   # will generate 'message', 'message_element', and 'message?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a label.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a label.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -1037,7 +1037,7 @@ module PageObject
     #   # will generate 'message', 'message_element', and 'message?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an area.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an area.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -1065,7 +1065,7 @@ module PageObject
     #   # will generate 'my_canvas_element' and 'my_canvas?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a canvas.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a canvas.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -1088,7 +1088,7 @@ module PageObject
     #   # will generate 'acdc_element' and 'acdc?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an audio element.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an audio element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -1111,7 +1111,7 @@ module PageObject
     #   # will generate 'movie_element' and 'movie?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a video element.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a video element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Watir and Selenium
@@ -1134,7 +1134,7 @@ module PageObject
     #   # will generate 'circle_element', and 'circle?' methods
     #
     # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a svg.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a svg.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -1159,7 +1159,7 @@ module PageObject
     #
     # @param [Symbol] the name used for the generated methods
     # @param [Symbol] the name of the tag for the element
-    # @param [Hash] identifier how we find an element.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -1192,7 +1192,7 @@ module PageObject
     #
     # @param [Symbol] the name used for the generated methods
     # @param [Symbol] the name of the tag for the element
-    # @param [Hash] identifier how we find an element.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -1221,7 +1221,7 @@ module PageObject
     #
     # @param [Symbol] the name used for the generated methods
     # @param [Symbol] the name of the tag for the element
-    # @param [Hash] identifier how we find an element.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
     #   * :css => Selenium only
@@ -1286,14 +1286,14 @@ module PageObject
     #
     # methods to fetch multiple elements of the same type
     #
-    # adds a method to the page object to retrun all of the matching elements
+    # adds a method to the page object to return all of the matching elements
     #
     # @example
     #   text_fields(:first_name, :id => "first_name")
     #   # will generate 'first_name_elements'
     #
     # @param  [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a text field.  You can use a multiple paramaters
+    # @param [Hash] identifier how we find a text field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid
     #   keys are the same ones supported by the standard methods.
     # @param optional block to be invoked when element method is called

--- a/lib/page-object/platforms/selenium_webdriver/button.rb
+++ b/lib/page-object/platforms/selenium_webdriver/button.rb
@@ -4,7 +4,7 @@ module PageObject
       module Button
         #
         # Override PageObject::PLatforms::SeleniumElement#text because
-        # #text does not reliabably return a value in Selenium
+        # #text does not reliably return a value in Selenium
         #
         def text
           raise "text is not available on button element in Selenium"

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -235,7 +235,7 @@ module PageObject
         #
         # @param [Integer] (defaults to: 5) seconds to wait before timing out
         # @param [String] the message to display if the event timeouts
-        # @param the block to execute when the event occurrs
+        # @param the block to execute when the event occurs
         #
         def wait_until(timeout=::PageObject.default_element_wait, message=nil, &block)
           wait = Object::Selenium::WebDriver::Wait.new({:timeout => timeout, :message => message})

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -200,7 +200,7 @@ module PageObject
         #
         # @param [Integer] (defaults to: 5) seconds to wait before timing out
         # @param [String] the message to display if the event timeouts
-        # @param the block to execute when the event occurrs
+        # @param the block to execute when the event occurs
         #
         def wait_until(timeout=::PageObject.default_element_wait, message=nil, &block)
           Object::Watir::Wait.until(timeout, message, &block)


### PR DESCRIPTION
There are a couple of spelling typos in the documentation - eg "paramaters" and "occurrs".
