### PR TITLE
Fix #wait_for_expected_title?

### DIFF
--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -76,8 +76,6 @@ module PageObject
         raise error_message.call unless has_expected_title
         has_expected_title
       end
-
-      alias_method :has_expected_title?, :wait_for_expected_title?
     end
 
     #

--- a/spec/page-object/accessors_spec.rb
+++ b/spec/page-object/accessors_spec.rb
@@ -24,7 +24,7 @@ describe  'accessors' do
       allow(browser).to receive(:title).and_return 'expected title'
       expect(browser).to_not receive(:wait_until)
 
-      expect(page).to have_expected_title
+      expect(page.wait_for_expected_title?).to be_truthy
     end
 
     it 'errors when it does not match' do
@@ -35,11 +35,6 @@ describe  'accessors' do
     it 'picks up when the title changes' do
       allow(browser).to receive(:title).and_return 'wrong title', 'expected title'
       expect(page.wait_for_expected_title?).to be_truthy
-    end
-
-    it '#has_expected_title?' do
-      allow(browser).to receive(:title).and_return 'wrong title', 'expected title'
-      expect(page).to have_expected_title
     end
   end
 end


### PR DESCRIPTION
`:wait_for_expected_title?` did not actually check to see if the `title` changed while waiting. Additionally, the documentation says it creates a `has_expected_title?` but it does not. To fix, I kept the `:wait_for_expected_title?` in case others were using it, but aliased a `:has_expected_title?` to it.
