### PR TITLE
Page objects rooted at elements

### DIFF
--- a/features/section.feature
+++ b/features/section.feature
@@ -1,0 +1,132 @@
+Feature: Sections
+
+  Background:
+    Given I am on the section elements page
+
+  Scenario: Getting the text from a section
+    When I get the text from the section
+    Then the text should include "page-object rocks!"
+
+  Scenario: Cannot find elements not in the section
+    When I access an element that is outside of the section
+    Then I should see that it doesn't exist in the section
+
+  Scenario: Finding a link within a section
+    When I search for a link located in a section
+    Then I should be able to click the section link
+
+  Scenario: Finding a button within a section
+    When I search for a button located in a section
+    Then I should be able to click the section button
+
+  Scenario: Finding a text field within a section
+    When I search for a text field located in a section
+    Then I should be able to type "123abc" in the section text field
+
+  Scenario: Finding a hidden field within a section
+    When I search for a hidden field located in a section
+    Then I should be able to see that the section hidden field contains "LeanDog"
+
+  Scenario: Finding a text area within a section
+    When I search for a text area located in a section
+    Then I should be able to type "abcdefg" in the section text area
+
+  Scenario: Finding a select list within a section
+    When I search for a select list located in a section
+    Then I should be able to select "Test 2" in the section select list
+
+  Scenario: Finding a file field within a section
+    When I search for a file field located in a section
+    Then I should be able to set the section file field
+
+  Scenario: Finding a checkbox within a section
+    When I search for a checkbox located in a section
+    Then I should be able to check the section checkbox
+
+  Scenario: Finding a radio button witin a section
+    When I search for a radio button located in a section
+    Then I should be able to select the section radio button
+
+  Scenario: Finding a div within a section
+    When I search for a div located in a section
+    Then I should see the text "page-object rocks!" in the section div
+
+  Scenario: Finding a span within a section
+    When I search for a span located in a section
+    Then I should see the text "My alert" in the section span
+
+  Scenario: Finding a table within a section
+    When I search for a table located in a section
+    Then the data for row "1" of the section table should be "Data1" and "Data2"
+
+  Scenario: Finding a table cell within a section
+    When I search the second table cell located in a table in a section
+    Then the section table cell should contain "Data2"
+
+  Scenario: Finding an image within a section
+    When I search for an image located in a section
+    Then the section image should be "106" pixels wide
+    And the section image should be "106" pixels tall
+
+  Scenario: Finding a form within a section
+    When I search for a form located in a section
+    Then I should be able to submit the section form
+
+  Scenario: Finding an ordered list within a section
+    When I search for an ordered list located in a section
+    Then the first section list items text should be "Number One"
+
+  Scenario: Finding an unordered list within a section
+    When I search for an unordered list located in a section
+    Then the first section list items text should be "Item One"
+
+  Scenario: Finding a list item section in an ordered list within a section
+    When I search for a list item section in an ordered list in a section
+    Then I should see the section list items text should be "Number One"
+
+  Scenario: Finding a h1 within a section
+    When I search for a h1 located in a section
+    Then I should see the section h1s text should be "h1's are cool"
+
+  Scenario: Finding a h2 within a section
+    When I search for a h2 located in a section
+    Then I should see the section h2s text should be "h2's are cool"
+
+  Scenario: Finding a h3 within a section
+    When I search for a h3 located in a section
+    Then I should see the section h3s text should be "h3's are cool"
+
+  Scenario: Finding a h4 within a section
+    When I search for a h4 located in a section
+    Then I should see the section h4s text should be "h4's are cool"
+
+  Scenario: Finding a h5 within a section
+    When I search for a h5 located in a section
+    Then I should see the section h5s text should be "h5's are cool"
+
+  Scenario: Finding a h6 within a section
+    When I search for a h6 located in a section
+    Then I should see the section h6s text should be "h6's are cool"
+
+  Scenario: Finding a paragraph within a section
+    When I search for a paragraph located in a section
+    Then I should see the section paragraphs text should be "This is a paragraph."
+
+  Scenario: Indexed property in section
+    Given I search for a link in an indexed property located in a section
+    Then I should see the text "Success" in the section indexed link
+
+  Scenario: Selecting multiple sections
+    When I select multiple sections
+    Then I should have a section collection containing the sections
+    And I can access any index of that collection of sections
+
+  Scenario: Searching section collection
+    Given I select multiple sections
+    When I search by a specific value of the section
+    Then I will find the first section with that value
+
+  Scenario: Filtering section collection
+    Given I select multiple sections
+    When I filter by a specific value of the sections
+    Then I will find all sections with that value

--- a/features/step_definitions/accessor_steps.rb
+++ b/features/step_definitions/accessor_steps.rb
@@ -6,6 +6,10 @@ Then /^the text should be "([^\"]*)"$/ do |expected_text|
   @text.should == expected_text
 end
 
+Then /^the text should include "([^\"]*)"$/ do |expected_text|
+  expect(@text).to include expected_text
+end
+
 Then /^I should be on the success page$/ do
   @page.text.should include 'Success'
   @page.title.should == 'Success'

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -1,0 +1,268 @@
+class Container
+  include PageObject
+
+  link(:section_link)
+  button(:section_button)
+  text_field(:section_text_field)
+  hidden_field(:section_hidden_field)
+  text_area(:section_text_area)
+  select_list(:section_select_list)
+  checkbox(:section_checkbox)
+  radio_button(:section_radio_button)
+  div(:section_div)
+  span(:section_span)
+  table(:section_table)
+  cell(:section_cell) { |page| page.section_table_element.cell_element(:index => 1) }
+  image(:section_image)
+  form(:section_form)
+  ordered_list(:section_ordered_list)
+  unordered_list(:section_unordered_list)
+  list_item(:section_list_item) { |page| page.section_ordered_list_element.list_item_element }
+  h1(:section_h1)
+  h2(:section_h2)
+  h3(:section_h3)
+  h4(:section_h4)
+  h5(:section_h5)
+  h6(:section_h6)
+  paragraph(:section_paragraph)
+  file_field(:section_file_field)
+
+  indexed_property(:indexed_list,[[:link,:indexed_link,href: '%s.html']])
+
+  unordered_list(:outside_section, :id => 'outer')
+end
+
+class InputSection
+  include PageObject
+
+  def value
+    @root.value
+  end
+end
+
+class SectionElementsPage
+  include PageObject
+
+  page_section(:container, Container, :id => 'div_id')
+  page_sections(:page_inputs, InputSection, :tag_name => 'input')
+end
+
+When(/^I get the text from the section$/) do
+  @text = @page.container.text
+end
+
+Given /^I am on the section elements page$/ do
+  @page = SectionElementsPage.new(@browser)
+  @page.navigate_to(UrlHelper.nested_elements)
+end
+
+When /^I search for a link located in a section$/ do
+  @link = @page.container.section_link_element
+end
+
+Then /^I should be able to click the section link$/ do
+  @link.click
+end
+
+When /^I search for a button located in a section$/ do
+  @button = @page.container.section_button_element
+end
+
+Then /^I should be able to click the section button$/ do
+  @button.click
+end
+
+When /^I search for a text field located in a section$/ do
+  @text_field = @page.container.section_text_field_element
+end
+
+Then /^I should be able to type "([^\"]*)" in the section text field$/ do |value|
+  @text_field.value = value
+end
+
+When /^I search for a hidden field located in a section$/ do
+  @hidden_field = @page.container.section_hidden_field_element
+end
+
+Then /^I should be able to see that the section hidden field contains "([^\"]*)"$/ do |value|
+  @hidden_field.value.should == value
+end
+
+When /^I search for a text area located in a section$/ do
+  @text_area = @page.container.section_text_area_element
+end
+
+Then /^I should be able to type "([^\"]*)" in the section text area$/ do |value|
+  @text_area.value = value
+end
+
+When /^I search for a select list located in a section$/ do
+  @select_list = @page.container.section_select_list_element
+end
+
+Then /^I should be able to select "([^\"]*)" in the section select list$/ do |value|
+  @select_list.select value
+end
+
+When /^I search for a checkbox located in a section$/ do
+  @checkbox = @page.container.section_checkbox_element
+end
+
+Then /^I should be able to check the section checkbox$/ do
+  @checkbox.check
+end
+
+When /^I search for a radio button located in a section$/ do
+  @radio = @page.container.section_radio_button_element
+end
+
+Then /^I should be able to select the section radio button$/ do
+  @radio.select
+end
+
+When /^I search for a div located in a section$/ do
+  @div = @page.container.section_div_element
+end
+
+Then /^I should see the text "([^\"]*)" in the section div$/ do |value|
+  @div.text.should == value
+end
+
+Then /^I should see the text "([^\"]*)" in the section indexed link$/ do |value|
+  @link.text.should == value
+end
+
+When /^I search for a span located in a section$/ do
+  @span = @page.container.section_span_element
+end
+
+Then /^I should see the text "([^\"]*)" in the section span$/ do |value|
+  @span.text.should == value
+end
+
+When /^I search for a table located in a section$/ do
+  @table = @page.container.section_table_element
+end
+
+Then /^the data for row "([^\"]*)" of the section table should be "([^\"]*)" and "([^\"]*)"$/ do |row, col1, col2|
+  table_row = @table[row.to_i - 1]
+  table_row[0].text.should == col1
+  table_row[1].text.should == col2
+end
+
+When /^I search the second table cell located in a table in a section$/ do
+  @cell = @page.container.section_cell_element
+end
+
+Then /^the section table cell should contain "([^\"]*)"$/ do |value|
+  @cell.text.should == value
+end
+
+When /^I search for an image located in a section$/ do
+  @image = @page.container.section_image_element
+end
+
+Then /^the section image should be "([^\"]*)" pixels wide$/ do |width|
+  @image.width.should == width.to_i
+end
+
+Then /^the section image should be "([^\"]*)" pixels tall$/ do |height|
+  @image.height.should == height.to_i
+end
+
+When /^I search for a form located in a section$/ do
+  @form = @page.container.section_form_element
+end
+
+Then /^I should be able to submit the section form$/ do
+  @form.submit
+end
+
+When /^I search for an ordered list located in a section$/ do
+  @list = @page.container.section_ordered_list_element
+end
+
+Then /^the first section list items text should be "([^\"]*)"$/ do |value|
+  @list[0].text.should == value
+end
+
+When /^I search for an unordered list located in a section$/ do
+  @list = @page.container.section_unordered_list_element
+end
+
+When /^I search for a list item section in an ordered list in a section$/ do
+  @li = @page.container.section_list_item_element
+end
+
+Then /^I should see the section list items text should be "([^\"]*)"$/ do |value|
+  @li.text.should == value
+end
+
+When /^I search for a h(\d+) located in a section$/ do |num|
+  @header = @page.container.send "section_h#{num}_element"
+end
+
+Then /^I should see the section h(\d+)s text should be "([^\"]*)"$/ do |num, value|
+  @header.text.should == value
+end
+
+When /^I search for a paragraph located in a section$/ do
+  @para = @page.container.section_paragraph_element
+end
+
+Then /^I should see the section paragraphs text should be "([^\"]*)"$/ do |value|
+  @para.text.should == value
+end
+
+When /^I search for a file field located in a section$/ do
+  @ff = @page.container.section_file_field_element
+end
+
+Then /^I should be able to set the section file field$/ do
+  @ff.value = __FILE__
+end
+
+When(/^I access an element that is outside of the section$/) do
+  @element = @page.container.outside_section_element
+end
+
+Then(/^I should see that it doesn't exist in the section$/) do
+  expect(@element).not_to exist
+end
+
+When(/^I select multiple sections$/) do
+  @sections = @page.page_inputs
+end
+
+Then(/^I should have a section collection containing the sections$/) do
+  expect(@sections).to be_an_instance_of(PageObject::SectionCollection)
+end
+
+When(/^I search by a specific value of the section$/) do
+  @element = @sections.find_by(:value => 'LeanDog')
+end
+
+Then(/^I will find the first section with that value$/) do
+  expect(@element).to be_a(PageObject)
+  expect(@element.value).to eq 'LeanDog'
+end
+
+When(/^I filter by a specific value of the sections$/) do
+  @elements = @sections.select_by(:value => /\w+/)
+end
+
+Then(/^I will find all sections with that value$/) do
+  expect(@elements).to be_a PageObject::SectionCollection
+  @elements.map(&:value).each do |element|
+    expect(element).to match(/\w+/)
+  end
+end
+
+And(/^I can access any index of that collection of sections$/) do
+  expect(@sections[0]).to be_a(PageObject)
+  expect(@sections[-1]).to be_a(PageObject)
+end
+
+Given(/^I search for a link in an indexed property located in a section$/) do
+  @link = @page.container.indexed_list['success'].indexed_link_element
+end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -36,7 +36,7 @@ class InputSection
   include PageObject
 
   def value
-    @root.value
+    root.value
   end
 end
 

--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -65,7 +65,7 @@ module PageObject
   end
 
   def initialize_browser(root)
-    @root = root_element_for root, PageObject::Platforms.get
+    @root_element = root_element_for root, PageObject::Platforms.get
     @browser = browser_for root, PageObject::Platforms.get
     include_platform_driver(root)
   end
@@ -146,7 +146,7 @@ module PageObject
   # Returns the text of the current page
   #
   def text
-    @root.text
+    root.text
   end
 
   #
@@ -400,6 +400,10 @@ module PageObject
   end
 
   private
+
+  def root
+    @root_element || browser_root_for(browser, PageObject::Platforms.get)
+  end
 
   def include_platform_driver(browser)
     @platform = load_platform(browser, PageObject::Platforms.get)

--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -7,6 +7,7 @@ require 'page-object/page_factory'
 require 'page-object/page_populator'
 require 'page-object/javascript_framework_facade'
 require 'page-object/indexed_properties'
+require 'page-object/sections'
 require 'page-object/widgets'
 
 require 'selenium/webdriver/common/error'
@@ -53,19 +54,20 @@ module PageObject
   # a method named initialize_accessors if it exists. Upon initialization of 
   # the page it will call a method named initialize_page if it exists.
   #
-  # @param [Watir::Browser or Selenium::WebDriver::Driver] the platform browser to use
+  # @param [Watir::Browser, Watir::HTMLElement or Selenium::WebDriver::Driver, Selenium::WebDriver::Element] the platform browser/element to use
   # @param [bool] open the page if page_url is set
   #
-  def initialize(browser, visit=false)
+  def initialize(root, visit=false)
     initialize_accessors if respond_to?(:initialize_accessors)
-    initialize_browser(browser)
+    initialize_browser(root)
     goto if visit && respond_to?(:goto)
     initialize_page if respond_to?(:initialize_page)
   end
 
-  def initialize_browser(browser)
-    @browser = browser
-    include_platform_driver(browser)
+  def initialize_browser(root)
+    @root = root_element_for root, PageObject::Platforms.get
+    @browser = browser_for root, PageObject::Platforms.get
+    include_platform_driver(root)
   end
 
   # @private
@@ -144,7 +146,7 @@ module PageObject
   # Returns the text of the current page
   #
   def text
-    platform.text
+    @root.text
   end
 
   #

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -1229,6 +1229,18 @@ module PageObject
       end
     end
 
+    def page_section(name, section_class, identifier)
+      define_method(name) do
+        section_class.new platform.element_for(:element, identifier.clone).element
+      end
+    end
+
+    def page_sections(name, section_class, identifier)
+      define_method(name) do
+        SectionCollection.new(platform.elements_for(:element, identifier.clone).map{|element| section_class.new element.element})
+      end
+    end
+
     #
     # methods to generate accessors for types that follow the same
     # pattern as element

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -1229,12 +1229,46 @@ module PageObject
       end
     end
 
+    #
+    # adds a method to return a page object rooted at an element
+    #
+    # @example
+    #   page_section(:navigation_bar, NavigationBar, :id => 'nav-bar')
+    #   # will generate 'navigation_bar' and 'navigation_bar?'
+    #
+    # @param [Symbol] the name used for the generated methods
+    # @param [Hash] identifier how we find an element.  You can use multiple parameters
+    #   by combining of any of the following except xpath.  The valid keys are:
+    #   * :class => Watir and Selenium
+    #   * :css => Selenium only
+    #   * :id => Watir and Selenium
+    #   * :index => Watir and Selenium
+    #   * :name => Watir and Selenium
+    #   * :xpath => Watir and Selenium
+    #
     def page_section(name, section_class, identifier)
       define_method(name) do
         section_class.new platform.element_for(:element, identifier.clone).element
       end
     end
 
+    #
+    # adds a method to return a collection of page objects rooted at elements
+    #
+    # @example
+    #   page_sections(:articles, Article, :class => 'article')
+    #   # will generate 'articles'
+    #
+    # @param [Symbol] the name used for the generated method
+    # @param [Hash] identifier how we find an element.  You can use a multiple parameters
+    #   by combining of any of the following except xpath.  The valid keys are:
+    #   * :class => Watir and Selenium
+    #   * :css => Selenium only
+    #   * :id => Watir and Selenium
+    #   * :index => Watir and Selenium
+    #   * :name => Watir and Selenium
+    #   * :xpath => Watir and Selenium
+    #
     def page_sections(name, section_class, identifier)
       define_method(name) do
         SectionCollection.new(platform.elements_for(:element, identifier.clone).map{|element| section_class.new element.element})

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -1249,7 +1249,7 @@ module PageObject
     #
     def page_section(name, section_class, identifier)
       define_method(name) do
-        section_class.new platform.element_for(:element, identifier.clone).element
+        platform.page_for(identifier, section_class)
       end
     end
 
@@ -1273,7 +1273,7 @@ module PageObject
     #
     def page_sections(name, section_class, identifier)
       define_method(name) do
-        SectionCollection.new(platform.elements_for(:element, identifier.clone).map{|element| section_class.new element.element})
+        platform.pages_for(identifier, section_class)
       end
     end
 

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -1237,6 +1237,7 @@ module PageObject
     #   # will generate 'navigation_bar' and 'navigation_bar?'
     #
     # @param [Symbol] the name used for the generated methods
+    # @param [Class] the class to instantiate for the element
     # @param [Hash] identifier how we find an element.  You can use multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
@@ -1260,6 +1261,7 @@ module PageObject
     #   # will generate 'articles'
     #
     # @param [Symbol] the name used for the generated method
+    # @param [Class] the class to instantiate for each element
     # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium

--- a/lib/page-object/loads_platform.rb
+++ b/lib/page-object/loads_platform.rb
@@ -46,7 +46,7 @@ module PageObject
         return adapter.browser_root_for(browser) if adapter.is_for?(browser)
       }
       message = 'Unable to pick a platform for the provided browser.'
-      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
+      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if browser.nil?
       raise message
     end
   end

--- a/lib/page-object/loads_platform.rb
+++ b/lib/page-object/loads_platform.rb
@@ -22,5 +22,23 @@ module PageObject
       message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if browser.nil?
       raise message 
     end
+
+    def browser_for root,adapters
+      adapters.each_value { |adapter|
+        return adapter.browser_for(root) if adapter.is_for?(root)
+      }
+      message = 'Unable to pick a platform for the provided browser.'
+      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
+      raise message
+    end
+
+    def root_element_for root, adapters
+      adapters.each_value { |adapter|
+        return adapter.root_element_for(root) if adapter.is_for?(root)
+      }
+      message = 'Unable to pick a platform for the provided browser.'
+      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
+      raise message
+    end
   end
 end

--- a/lib/page-object/loads_platform.rb
+++ b/lib/page-object/loads_platform.rb
@@ -40,5 +40,14 @@ module PageObject
       message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
       raise message
     end
+
+    def browser_root_for browser, adapters
+      adapters.each_value { |adapter|
+        return adapter.browser_root_for(browser) if adapter.is_for?(browser)
+      }
+      message = 'Unable to pick a platform for the provided browser.'
+      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
+      raise message
+    end
   end
 end

--- a/lib/page-object/loads_platform.rb
+++ b/lib/page-object/loads_platform.rb
@@ -15,39 +15,31 @@ module PageObject
     # @returns [PageObject] 
     #
     def load_platform(browser, adapters)
-      adapters.each_value { |adapter|
-        return adapter.create_page_object(browser) if adapter.is_for?(browser)
-      }
-      message = 'Unable to pick a platform for the provided browser.'
-      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if browser.nil?
-      raise message 
+      adapter_for(browser,adapters).create_page_object(browser)
     end
 
     def browser_for root,adapters
-      adapters.each_value { |adapter|
-        return adapter.browser_for(root) if adapter.is_for?(root)
+      adapter_for(root,adapters).browser_for(root)
+    end
+
+    def adapter_for element_or_browser, adapters
+      adapter = adapters.values.find { |adapter|
+        adapter.is_for?(element_or_browser)
       }
-      message = 'Unable to pick a platform for the provided browser.'
-      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
-      raise message
+      unless adapter
+        message = "Unable to pick a platform for the provided browser or element: #{element_or_browser.inspect}."
+        message += "\nnil was passed to the PageObject constructor instead of a valid browser or element object." if element_or_browser.nil?
+        raise message
+      end
+      adapter
     end
 
     def root_element_for root, adapters
-      adapters.each_value { |adapter|
-        return adapter.root_element_for(root) if adapter.is_for?(root)
-      }
-      message = 'Unable to pick a platform for the provided browser.'
-      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if root.nil?
-      raise message
+      adapter_for(root,adapters).root_element_for(root)
     end
 
     def browser_root_for browser, adapters
-      adapters.each_value { |adapter|
-        return adapter.browser_root_for(browser) if adapter.is_for?(browser)
-      }
-      message = 'Unable to pick a platform for the provided browser.'
-      message += "\nnil was passed to the PageObject constructor instead of a valid browser object." if browser.nil?
-      raise message
+      adapter_for(browser,adapters).browser_root_for(browser)
     end
   end
 end

--- a/lib/page-object/platforms/selenium_webdriver.rb
+++ b/lib/page-object/platforms/selenium_webdriver.rb
@@ -18,8 +18,11 @@ module PageObject
       end
 
       def self.root_element_for root
-        root = root.find_element(:tag_name, 'html') unless root.is_a? ::Selenium::WebDriver::Element
-        Elements::Element.new root, platform: :selenium_webdriver
+        Elements::Element.new root, platform: :selenium_webdriver if root.is_a?(::Selenium::WebDriver::Element)
+      end
+
+      def self.browser_root_for browser
+        browser.find_element(tag_name: 'html')
       end
     end
   end

--- a/lib/page-object/platforms/selenium_webdriver.rb
+++ b/lib/page-object/platforms/selenium_webdriver.rb
@@ -9,7 +9,17 @@ module PageObject
 
       def self.is_for?(browser)
         require 'selenium-webdriver'
-        browser.is_a? ::Selenium::WebDriver::Driver
+        browser.is_a?(::Selenium::WebDriver::Driver) || browser.is_a?(::Selenium::WebDriver::Element)
+      end
+
+      def self.browser_for root
+        return root if root.is_a?(::Selenium::WebDriver::Driver)
+        Selenium::WebDriver::Driver.new(root.send(:bridge))
+      end
+
+      def self.root_element_for root
+        root = root.find_element(:tag_name, 'html') unless root.is_a? ::Selenium::WebDriver::Element
+        Elements::Element.new root, platform: :selenium_webdriver
       end
     end
   end

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -988,6 +988,22 @@ module PageObject
           find_selenium_elements(identifier, Elements::Element, tag.to_s)
         end
 
+        #
+        # platform method to return a PageObject rooted at an element
+        # See PageObject::Accessors#page_section
+        #
+        def page_for(identifier, page_class)
+          find_selenium_page(identifier, page_class)
+        end
+
+        #
+        # platform method to return a collection of PageObjects rooted at elements
+        # See PageObject::Accessors#page_sections
+        #
+        def pages_for(identifier, page_class)
+          SectionCollection.new(find_selenium_pages(identifier, page_class))
+        end
+
        #
         # platform method to return a svg element
         #
@@ -1069,6 +1085,40 @@ module PageObject
           end
           @browser.switch_to.default_content unless frame_identifiers.nil?
           elements.map { |element| type.new(element, :platform => :selenium_webdriver) }
+        end
+
+        def find_selenium_pages(identifier, page_class)
+          regexp = delete_regexp(identifier)
+          how, what, frame_identifiers = parse_identifiers(identifier, Elements::Element, 'element')
+          switch_to_frame(frame_identifiers)
+          unless regexp
+            elements = @browser.find_elements(how, what)
+          else
+            eles = @browser.find_elements(how, what)
+            elements = eles.find_all {|ele| matches_selector?(ele, regexp[0], regexp[1])}
+          end
+          @browser.switch_to.default_content unless frame_identifiers.nil?
+          elements.map { |element| page_class.new(element) }
+        end
+
+        def find_selenium_page(identifier, page_class)
+          type, tag = Elements::Element, 'element'
+          regexp = delete_regexp(identifier)
+          how, what, frame_identifiers = parse_identifiers(identifier, type, tag)
+          switch_to_frame(frame_identifiers)
+          begin
+            unless regexp
+              element = @browser.find_element(how, what)
+            else
+              elements = @browser.find_elements(how, what)
+              element = elements.find {|ele| matches_selector?(ele, regexp[0], regexp[1])}
+            end
+          rescue Selenium::WebDriver::Error::NoSuchElementError
+            @browser.switch_to.default_content unless frame_identifiers.nil?
+            return build_null_object(identifier, type, tag, nil)
+          end
+          @browser.switch_to.default_content unless frame_identifiers.nil?
+          page_class.new(element)
         end
 
         def build_null_object(identifier, type, tag, other)

--- a/lib/page-object/platforms/watir_webdriver.rb
+++ b/lib/page-object/platforms/watir_webdriver.rb
@@ -18,8 +18,11 @@ module PageObject
       end
 
       def self.root_element_for root
-        root = root.element unless root.is_a? ::Watir::HTMLElement
-        Elements::Element.new root, :platform => :watir_webdriver
+        Elements::Element.new root, :platform => :watir_webdriver if root.is_a? ::Watir::HTMLElement
+      end
+
+      def self.browser_root_for browser
+        browser.element
       end
     end
   end

--- a/lib/page-object/platforms/watir_webdriver.rb
+++ b/lib/page-object/platforms/watir_webdriver.rb
@@ -1,7 +1,7 @@
 module PageObject
   module Platforms
     module WatirWebDriver
-      
+
       def self.create_page_object(browser)
         require 'page-object/platforms/watir_webdriver/page_object'
         return WatirWebDriver::PageObject.new(browser)
@@ -9,7 +9,17 @@ module PageObject
 
       def self.is_for?(browser)
         require 'watir-webdriver'
-        browser.is_a?(::Watir::Browser)
+        browser.is_a?(::Watir::Browser) || browser.is_a?(::Watir::HTMLElement)
+      end
+
+      def self.browser_for root
+        return root if root.is_a?(::Watir::Browser)
+        root.browser
+      end
+
+      def self.root_element_for root
+        root = root.element unless root.is_a? ::Watir::HTMLElement
+        Elements::Element.new root, :platform => :watir_webdriver
       end
     end
   end

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -918,6 +918,22 @@ module PageObject
         end
 
         #
+        # platform method to return a PageObject rooted at an element
+        # See PageObject::Accessors#page_section
+        #
+        def page_for(identifier, page_class)
+          find_watir_page(identifier, page_class)
+        end
+
+        #
+        # platform method to return a collection of PageObjects rooted at elements
+        # See PageObject::Accessors#page_sections
+        #
+        def pages_for(identifier, page_class)
+          SectionCollection.new(find_watir_pages(identifier, page_class))
+        end
+
+        #
         # platform method to return a svg element
         #
         def svg_for(identifier)
@@ -968,6 +984,20 @@ module PageObject
           element = @browser.instance_eval "#{nested_frames(frame_identifiers)}#{the_call}"
           switch_to_default_content(frame_identifiers)
           type.new(element, :platform => :watir_webdriver)
+        end
+
+        def find_watir_pages(identifier, page_class)
+          identifier, frame_identifiers = parse_identifiers(identifier, Elements::Element, 'element')
+          elements = @browser.instance_eval "#{nested_frames(frame_identifiers)}elements(identifier)"
+          switch_to_default_content(frame_identifiers)
+          elements.map { |element| page_class.new(element) }
+        end
+
+        def find_watir_page(identifier, page_class)
+          identifier, frame_identifiers = parse_identifiers(identifier, Elements::Element, 'element')
+          element = @browser.instance_eval "#{nested_frames(frame_identifiers)}element(identifier)"
+          switch_to_default_content(frame_identifiers)
+          page_class.new(element)
         end
 
         def process_watir_call(the_call, type, identifier, value=nil, tag_name=nil)

--- a/lib/page-object/sections.rb
+++ b/lib/page-object/sections.rb
@@ -6,8 +6,8 @@ module PageObject
       @sections = sections
     end
 
-    def each
-      @sections.each
+    def each &block
+      @sections.each &block
     end
 
     def [] index

--- a/lib/page-object/sections.rb
+++ b/lib/page-object/sections.rb
@@ -1,0 +1,29 @@
+module PageObject
+  class SectionCollection
+    include Enumerable
+
+    def initialize sections
+      @sections = sections
+    end
+
+    def each
+      @sections.each
+    end
+
+    def [] index
+      @sections[index]
+    end
+
+    def find_by values_hash
+      @sections.find {|section|
+        values_hash.all? {|method,value| value === section.public_send(method)}
+      }
+    end
+
+    def select_by values_hash
+      SectionCollection.new @sections.select {|section|
+        values_hash.all? {|method,value| value === section.public_send(method)}
+      }
+    end
+  end
+end

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'selenium-webdriver', '>= 2.44.0'
   s.add_dependency 'page_navigation', '>= 0.9'
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 3.1.0'
   s.add_development_dependency 'cucumber', '>= 1.3.0'
   s.add_development_dependency 'yard', '>= 0.7.2'
   s.add_development_dependency 'rack', '>= 1.0'

--- a/spec/page-object/loads_platform_spec.rb
+++ b/spec/page-object/loads_platform_spec.rb
@@ -34,19 +34,19 @@ describe TestLoadsPlatform do
   end
 
   context "When an unknow object is passed in" do
-    let(:basic_message) { 'Unable to pick a platform for the provided browser.' }
+    let(:basic_message) { 'Unable to pick a platform for the provided browser or element:' }
     
     it "should throw an exception" do
       expect {
         subject.load_platform("browser", {})
-      }.to raise_error(basic_message)
+      }.to raise_error("#{basic_message} \"browser\".")
     end
 
     it "should notify when the browser is nil" do
       begin
         subject.load_platform(nil, {})
       rescue Exception => e
-        expect(e.message).to eql "#{basic_message}\nnil was passed to the PageObject constructor instead of a valid browser object."
+        expect(e.message).to eql "#{basic_message} nil.\nnil was passed to the PageObject constructor instead of a valid browser or element object."
       end
     end
   end

--- a/spec/page-object/page-object_spec.rb
+++ b/spec/page-object/page-object_spec.rb
@@ -169,6 +169,7 @@ describe PageObject do
     
     context "when using WatirPageObject" do
       it "should display the page text" do
+        expect(watir_browser).to receive(:element).and_return(watir_browser)
         expect(watir_browser).to receive(:text).and_return("browser text")
         expect(watir_page_object.text).to eql "browser text"
       end

--- a/spec/page-object/page_section_spec.rb
+++ b/spec/page-object/page_section_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'page-object/elements'
+
+class Container
+  include PageObject
+end
+class SectionsPage
+  include PageObject
+
+  page_section(:container, Container, :id => 'blah')
+  page_sections(:containers, Container, :class => 'foo')
+end
+
+describe PageObject::Accessors do
+  context 'when using watir' do
+    let(:watir_browser) { mock_watir_browser }
+    let(:watir_page_object) { SectionsPage.new(watir_browser) }
+
+    it 'it should find a page section' do
+      expect(watir_browser).to receive(:element).with(:id => 'blah').and_return(watir_browser)
+      section = watir_page_object.container
+      expect(section).to be_instance_of Container
+    end
+    it 'it should find page sections' do
+      expect(watir_browser).to receive(:elements).with(:class => 'foo').and_return([watir_browser, watir_browser])
+      sections = watir_page_object.containers
+      expect(sections).to be_instance_of(PageObject::SectionCollection)
+      sections.each do |section|
+        expect(section).to be_instance_of(Container)
+      end
+    end
+  end
+  context 'when using selenium' do
+    let(:selenium_browser) { mock_selenium_browser }
+    let(:selenium_page_object) { SectionsPage.new(selenium_browser) }
+
+    it 'it should find a page section' do
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      section = selenium_page_object.container
+      expect(section).to be_instance_of Container
+    end
+    it 'it should find page sections' do
+      expect(selenium_browser).to receive(:find_elements).with(:class, 'foo').and_return([selenium_browser, selenium_browser])
+      sections = selenium_page_object.containers
+      expect(sections).to be_instance_of(PageObject::SectionCollection)
+      sections.each do |section|
+        expect(section).to be_instance_of(Container)
+      end
+    end
+  end
+end
+describe PageObject::SectionCollection do
+  ContainedItem = Struct.new(:type, :name)
+  let(:section_collection) do
+    contained_items = [ContainedItem.new(:sandwich, :reuben), ContainedItem.new(:soup, :lobster_bisque), ContainedItem.new(:sandwich, :dagwood)]
+    PageObject::SectionCollection.new(contained_items)
+  end
+  it 'should be indexed to the sections' do
+    expect(section_collection[0]).to be_an_instance_of ContainedItem
+    expect(section_collection[-1]).to be_an_instance_of ContainedItem
+  end
+  it 'should be able to iterate over the sections' do
+    section_collection.each do |section|
+      expect(section).to be_an_instance_of ContainedItem
+    end
+  end
+  it 'should find a section by one of its values' do
+    expect(section_collection.find_by(name: :dagwood).name).to eq :dagwood
+  end
+  it 'should find all sections matching a value' do
+    expect(section_collection.select_by(type: :sandwich).map(&:type)).to eq [:sandwich, :sandwich]
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ end
 
 def mock_selenium_browser
   selenium_browser = double('selenium')
-  allow(selenium_browser).to receive(:is_a?).with(Watir::Browser).and_return(false)
+  allow(selenium_browser).to receive(:is_a?).with(anything).and_return(false)
   allow(selenium_browser).to receive(:is_a?).with(Selenium::WebDriver::Driver).and_return(true)
   selenium_browser
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,8 @@ def mock_adapter(browser, page_object)
   allow(adapter).to receive(:is_for?).with(anything()).and_return false
   allow(adapter).to receive(:is_for?).with(browser).and_return true
   allow(adapter).to receive(:create_page_object).and_return page_object
+  allow(adapter).to receive(:root_element_for).and_return browser
+  allow(adapter).to receive(:browser_for).and_return browser
   adapter
 end
 


### PR DESCRIPTION
This is another solution to issue #263 This enhances page objects to have a root element. This root element can be any element in the DOM or the <html> node. All the tests over the functionality added from the other branch are in this branch too, but just using page objects instead of a separate section class. There is also a test for indexed properties, which doesn't work in the other branch.