### PR TITLE
Support Watir-Nokogiri

### DIFF
--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -210,12 +210,12 @@ module PageObject
         if platform[:platform] == :watir_webdriver
           require 'page-object/platforms/watir_webdriver/element'
           require 'page-object/platforms/watir_webdriver/page_object'
-          self.class.send :include,  ::PageObject::Platforms::WatirWebDriver::Element
+          self.send :extend,  ::PageObject::Platforms::WatirWebDriver::Element
           @platform = ::PageObject::Platforms::WatirWebDriver::PageObject.new(@element)
         elsif platform[:platform] == :selenium_webdriver
           require 'page-object/platforms/selenium_webdriver/element'
           require 'page-object/platforms/selenium_webdriver/page_object'
-          self.class.send :include, ::PageObject::Platforms::SeleniumWebDriver::Element
+          self.send :extend, ::PageObject::Platforms::SeleniumWebDriver::Element
           @platform = ::PageObject::Platforms::SeleniumWebDriver::PageObject.new(@element)
         else
           raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"

--- a/lib/page-object/platforms/watir_webdriver.rb
+++ b/lib/page-object/platforms/watir_webdriver.rb
@@ -9,7 +9,14 @@ module PageObject
 
       def self.is_for?(browser)
         require 'watir-webdriver'
-        browser.is_a?(::Watir::Browser)
+        res=browser.is_a?(::Watir::Browser)
+
+        unless res && Gem::Specification.find_all_by_name('watir-nokogiri').any?
+          require 'watir-nokogiri'
+          res= browser.is_a?(::WatirNokogiri::Document)
+        end
+
+        res
       end
     end
   end


### PR DESCRIPTION
Pull request to also support : https://github.com/jkotests/watir-nokogiri

__Goal:__
Given a rails project with integration tests build around page-objects. 
Now we also want to write functional tests on the controller and quickly test the @response.body of the ActionController::TestCase (i.e. rendered HTML of the view)  for the presence of some elements using the mapped elements of the page objects (i.e. avoid repeating the xpaths here). 

__Issue:__
For these functional tests  selenium-webdriver or watir-webdriver cannot be used directly as no rails app is running. We do not want to run one as the requests will be considerably slower then the current approach with ActionController::TestCase (Controller is instantiated directly)

__Solution:__
A gem exists, called watir-nokogiri, which allows the use of the watir API on a chunk of HTML. 
In other words the WatirNokogiri::Document object can be used instead of a  Watir::Browser object to verify whether the mapped elements of the page object are present in the HTML

This is a similar solution as the one Capybara provides : http://robots.thoughtbot.com/use-capybara-on-any-html-fragment-or-page

Note: Not all the Watir API commands are supported, only the ones for identifying/reading elements on the HTML page. An error  "Not implemented" is raised for the other methods

__Example:__
browser= WatirNokogiri::Document.start('my_page.html')
my_page_object = MyPageObject.new(browser)

allows to use:
on_page(MyPageObject).my_mapped_field_element.exists? 
or even:
on_page(MyPageObject).my_mapped_field?