### PR TITLE
Improve element collection performance by moving requires out of object instantiation

### DIFF
--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -9,6 +9,11 @@ require 'page-object/javascript_framework_facade'
 require 'page-object/indexed_properties'
 require 'page-object/widgets'
 
+require 'page-object/platforms/watir_webdriver/element'
+require 'page-object/platforms/watir_webdriver/page_object'
+require 'page-object/platforms/selenium_webdriver/element'
+require 'page-object/platforms/selenium_webdriver/page_object'
+
 require 'selenium/webdriver/common/error'
 #
 # Module that when included adds functionality to a page object.  This module

--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -208,13 +208,9 @@ module PageObject
 
       def include_platform_for platform
         if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/element'
-          require 'page-object/platforms/watir_webdriver/page_object'
           self.class.send :include,  ::PageObject::Platforms::WatirWebDriver::Element
           @platform = ::PageObject::Platforms::WatirWebDriver::PageObject.new(@element)
         elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/element'
-          require 'page-object/platforms/selenium_webdriver/page_object'
           self.class.send :include, ::PageObject::Platforms::SeleniumWebDriver::Element
           @platform = ::PageObject::Platforms::SeleniumWebDriver::PageObject.new(@element)
         else

--- a/lib/page-object/platforms/selenium_webdriver.rb
+++ b/lib/page-object/platforms/selenium_webdriver.rb
@@ -3,7 +3,6 @@ module PageObject
     module SeleniumWebDriver
 
       def self.create_page_object(browser)
-        require 'page-object/platforms/selenium_webdriver/page_object'
         SeleniumWebDriver::PageObject.new(browser)
       end
 

--- a/lib/page-object/platforms/watir_webdriver.rb
+++ b/lib/page-object/platforms/watir_webdriver.rb
@@ -3,7 +3,6 @@ module PageObject
     module WatirWebDriver
       
       def self.create_page_object(browser)
-        require 'page-object/platforms/watir_webdriver/page_object'
         return WatirWebDriver::PageObject.new(browser)
       end
 

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'selenium-webdriver', '>= 2.44.0'
   s.add_dependency 'page_navigation', '>= 0.9'
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 3.1.0'
   s.add_development_dependency 'cucumber', '>= 1.3.0'
   s.add_development_dependency 'yard', '>= 0.7.2'
   s.add_development_dependency 'rack', '>= 1.0'


### PR DESCRIPTION
Move requires of files to central location because they slow things down, especially when grabbing a collection of elements.