### PR TITLE
Remove default locator for multiple nested widgets

### DIFF
--- a/lib/page-object/widgets.rb
+++ b/lib/page-object/widgets.rb
@@ -99,7 +99,7 @@ module PageObject
 
     def self.define_multiple_nested_accessor(base, widget_tag)
       base.send(:define_method, "#{widget_tag}_elements") do |*args|
-        identifier = args[0] ? args[0] : {:index => 0}
+        identifier = args[0] ? args[0] : {}
         @platform.send("#{widget_tag}s_for", identifier.clone)
       end
     end


### PR DESCRIPTION
The default locator for multiple nested widgets is currently `:index => 0`, which is not a valid locator for Watir:

````````
C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/locators/element_locator.rb:105:in `find_all_by_multiple': can't locate all elements by :index (ArgumentError)
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/locators/element_locator.rb:50:in `locate_all'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/element_collection.rb:92:in `elements'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/element_collection.rb:86:in `to_a'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/element_collection.rb:29:in `each'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.1.0/lib/page-object/platforms/watir_webdriver/page_object.rb:979:in `map'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.1.0/lib/page-object/platforms/watir_webdriver/page_object.rb:979:in `find_watir_elements'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.1.0/lib/page-object/widgets.rb:68:in `block in define_multiple_watir_accessor'
	from C:/Ruby193/lib/ruby/gems/1.9.1/gems/page-object-1.1.0/lib/page-object/widgets.rb:103:in `block in define_multiple_nested_accessor'
	from pageobject.rb:46:in `<main>'
````````