### PR TITLE
implement css support for watir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,25 @@
-sudo: false
-language: ruby
-cache: bundler
+sudo: required
+dist: trusty
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - jruby-19mode
-
+  - 2.2.5
+  - 2.3.1
+cache: bundler
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+ - export CHROME_BIN=/usr/bin/google-chrome
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+ - sudo apt-get update
+ - sudo apt-get install -y libappindicator1 fonts-liberation
+ - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+ - sudo dpkg -i google-chrome*.deb
+ - CHROMEDRIVER_VERSION=$(curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+ - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+ - unzip chromedriver_linux64.zip
+ - chmod +x chromedriver
+ - sudo mv chromedriver /usr/local/bin
 
-script:
-  - "bundle exec rake test_with_coveralls"
+script: bundle exec rake $RAKE_TASK
+env:
+  - RAKE_TASK=spec
+  - RAKE_TASK=features:watir_webdriver
+  - RAKE_TASK=features:selenium_webdriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ before_script:
 script: bundle exec rake $RAKE_TASK
 env:
   - RAKE_TASK=spec
-  - RAKE_TASK=features:watir_webdriver
+  - RAKE_TASK=features:watir_webdriver WATIR_BRANCH=master
   - RAKE_TASK=features:selenium_webdriver

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,9 @@ gem 'guard-cucumber'
 gem 'net-http-persistent'
 gem 'coveralls', require: false
 
+if ENV['WATIR_BRANCH']
+  gem 'watir', :git => 'https://github.com/watir/watir.git', :branch => ENV['WATIR_BRANCH']
+end
+
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/cheezy/page-object/badge.svg?nocache)](https://coveralls.io/r/cheezy/page-object)
 
 
-A simple gem that assists in creating flexible page objects for testing browser based applications. The goal is to facilitate creating abstraction layers in your tests to decouple the tests from the item they are testing and to provide a simple interface to the elements on a page. It works with both watir-webdriver and selenium-webdriver.
+A simple gem that assists in creating flexible page objects for testing browser based applications. The goal is to facilitate creating abstraction layers in your tests to decouple the tests from the item they are testing and to provide a simple interface to the elements on a page. It works with both watir and selenium-webdriver.
 
 ## Documentation
 
@@ -80,7 +80,7 @@ login_page.login_with 'cheezy', 'secret'
 ````
 
 ### Creating your page object
-page-object supports both [watir-webdriver](https://github.com/jarib/watir-webdriver) and [selenium-webdriver](http://seleniumhq.org/docs/03_webdriver.html). The one used will be determined by which driver you pass into the constructor of your page object. The page object can be created like this:
+page-object supports both [watir](https://github.com/watir/watir) and [selenium-webdriver](http://seleniumhq.org/docs/03_webdriver.html). The one used will be determined by which driver you pass into the constructor of your page object. The page object can be created like this:
 
 ````ruby
 browser = Watir::Browser.new :firefox

--- a/features/check_box.feature
+++ b/features/check_box.feature
@@ -25,14 +25,6 @@ Feature: Check Box
     | index     |
     | value     |
     | label     |
-
-  @selenium_only
-  Scenario Outline: Locating check boxes on the page
-    When I search for the check box by "<search_by>"
-    Then I should be able to check the check box
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating check boxes using multiple parameters

--- a/features/file_field.feature
+++ b/features/file_field.feature
@@ -20,14 +20,6 @@ Feature: File Field
     | title     |
     | index     |
     | label     |
-
-  @selenium_only
-  Scenario Outline: Locating file fields on the Page
-    When I search for the file field by "<search_by>"
-    Then I should be able to set the file field
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating file fields using multiple parameters

--- a/features/form.feature
+++ b/features/form.feature
@@ -18,14 +18,6 @@ Feature: Form
     | xpath     |
     | index     |
     | action    |
-
-  @selenium_only
-  Scenario Outline: Locating a form on the page
-    When I locate the form by "<search_by>"
-    Then I should be able to submit the form
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating table using multiple parameters

--- a/features/hidden_field.feature
+++ b/features/hidden_field.feature
@@ -20,14 +20,6 @@ Feature: Hidden Fields
     | index     |
     | text      |
     | value     |
-
-  @selenium_only
-  Scenario Outline: Locating hidden fields on the Page
-    When I search for the hidden field by "<search_by>"
-    Then the hidden field element should contain "12345"
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating a hidden field using multiple parameters

--- a/features/image.feature
+++ b/features/image.feature
@@ -22,15 +22,6 @@ Feature: Image
     | index     |
     | alt       |
     | src       |
-
-  @selenium_only
-  Scenario Outline: Locating an image on the page
-    When I get the image element by "<search_by>"
-    Then the image should be "106" pixels wide
-    And the image should be "106" pixels tall
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating an image using multiple parameters

--- a/features/ordered_list.feature
+++ b/features/ordered_list.feature
@@ -21,17 +21,6 @@ Feature: Ordered list
     | xpath     |
     | index     |
     | name      |
-
-  @selenium_only
-  Scenario Outline: Locating ordered lists on the page
-    When I search for the ordered list by "<search_by>"
-    And I get the first item from the list
-    Then the list items text should be "Number One"
-    And the list should contain 3 items
-    And each item should contain "Number"
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating ordered lists using multiple parameters

--- a/features/radio_button.feature
+++ b/features/radio_button.feature
@@ -26,15 +26,6 @@ Feature: Radio Buttons
     | value     |
     | index     |
     | label     |
-
-  @selenium_only
-  Scenario Outline: Locating radio buttons on the Page
-    When I search for the radio button by "<search_by>"
-    And I select the radio button
-    Then the "Milk" radio button should be selected
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating radio buttons using multiple parameters

--- a/features/select_list.feature
+++ b/features/select_list.feature
@@ -28,16 +28,6 @@ Feature: Select List
     | xpath     |
     | index     |
     | label     |
-
-  @selenium_only
-  Scenario Outline: Locating select lists on the Page using Selenium
-    When I search for the select list by "<search_by>"
-    Then I should be able to select "Test 2"
-    And the value for the selected item should be "Test 2"
-    And the value for the option should be "option2"
-
-  Examples:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating a select list using multiple parameters

--- a/features/step_definitions/accessor_steps.rb
+++ b/features/step_definitions/accessor_steps.rb
@@ -3,7 +3,7 @@ Then /^the current item should be "([^\"]*)"$/ do |expected_text|
 end
 
 Then /^the text should be "([^\"]*)"$/ do |expected_text|
-  @text.should == expected_text
+  @text.tr("\n", ' ').should == expected_text
 end
 
 Then /^the text should include "([^\"]*)"$/ do |expected_text|

--- a/features/step_definitions/file_field_steps.rb
+++ b/features/step_definitions/file_field_steps.rb
@@ -3,7 +3,7 @@ When /^I set the file field to the step definition file$/ do
 end
 
 Then /^its\' value should equal that file$/ do
-  __FILE__.should include @page.file_field_id_element.value
+  __FILE__.should include @page.file_field_id_element.value[/[^\\]*$/]
 end
 
 When /^I search for the file field by "([^\"]*)"$/ do |how|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../../', 'lib'))
 
 require 'rspec'
-require 'watir-webdriver'
+require 'watir'
 require 'selenium-webdriver'
 require 'page-object'
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,8 +1,3 @@
-
 Before do
   @browser = PageObject::PersistantBrowser.get_browser
-end
-
-at_exit do
-  PageObject::PersistantBrowser.quit
 end

--- a/features/support/persistent_browser.rb
+++ b/features/support/persistent_browser.rb
@@ -5,16 +5,14 @@ module PageObject
     @@browser = false
     def self.get_browser
       if !@@browser
-        target = ENV['BROWSER']
-        target = 'firefox_local' unless target
+        target = ENV['BROWSER'] || 'local_chrome'
 
         if is_remote?(target)
           require File.dirname(__FILE__) + "/targets/#{target}"
           extend Target
         end
-        
-        @@browser =  watir_browser(target) if ENV['DRIVER'] == 'WATIR'
-        @@browser =  selenium_browser(target) if ENV['DRIVER'] == 'SELENIUM'
+
+        @@browser =  ENV['DRIVER'] == 'SELENIUM' ? selenium_browser(target) : watir_browser(target)
       end
       @@browser
     end
@@ -36,7 +34,8 @@ module PageObject
                            :url => url,
                            :desired_capabilities => desired_capabilities)
       else
-        Watir::Browser.new :firefox, :http_client => client
+        browser = target.gsub('local_', '').to_sym
+        Watir::Browser.new browser, :http_client => client
       end
     end
 
@@ -47,7 +46,8 @@ module PageObject
                                 :url => url,
                                 :desired_capabilities => desired_capabilities)
       else
-        Selenium::WebDriver.for :firefox, :http_client => client
+        browser = target.gsub('local_', '').to_sym
+        Selenium::WebDriver.for browser, :http_client => client
       end
     end
 

--- a/features/table.feature
+++ b/features/table.feature
@@ -82,6 +82,7 @@ Feature: Table
     | xpath     |
     | index     |
     | name      |
+    | css       |
 
   Scenario: Matching the expected table with the table on the Page
     When I retrieve a table element
@@ -89,16 +90,6 @@ Feature: Table
       | Table | Header |
       | Data1 | Data2  |
       | Data3 | Data4  |
-
-
-  @selenium_only
-  Scenario Outline: Locating table cells on the Page
-    When I retrieve a table element by "<search_by>"
-    Then the data for row "2" should be "Data1" and "Data2"
-
-  Scenarios:
-    | search_by |
-    | css       |
 
   Scenario Outline: Locating table using multiple parameters
     When I retrieve a table element by "<param1>" and "<param2>"

--- a/features/text_area.feature
+++ b/features/text_area.feature
@@ -20,14 +20,6 @@ Feature: Text Area
     | xpath     |
     | index     |
     | label     |
-
-  @selenium_only
-  Scenario Outline: Locating text area on the Page
-    When I search for the text area by "<search_by>"
-    Then I should be able to type "I found it" into the area
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating a text area using multiple parameters

--- a/features/text_field.feature
+++ b/features/text_field.feature
@@ -22,9 +22,8 @@ Feature: Text Fields
     | xpath      |
     | index      |
     | title      |
-    | text       |
     | label      |
-    | css       |
+    | css        |
 
 
   @watir_only
@@ -34,6 +33,14 @@ Feature: Text Fields
   Examples:
     | search_by  |
     | data_field |
+
+  @selenium_only
+  Scenario Outline: Locating text fields on the Page using Watir
+    When I search for the text field by "<search_by>"
+    Then I should be able to type "I found it" into the field
+  Examples:
+    | search_by  |
+    | text       |
 
   Scenario Outline: Locating a text field using multiple parameters
     When I search for the text field by "<param1>" and "<param2>"

--- a/features/text_field.feature
+++ b/features/text_field.feature
@@ -22,7 +22,9 @@ Feature: Text Fields
     | xpath      |
     | index      |
     | title      |
+    | text       |
     | label      |
+    | css       |
 
 
   @watir_only
@@ -32,16 +34,6 @@ Feature: Text Fields
   Examples:
     | search_by  |
     | data_field |
-
-  @selenium_only
-  Scenario Outline: Locating text fields on the Page using Selenium
-    When I search for the text field by "<search_by>"
-    Then I should be able to type "I found it" into the field
-
-  Examples:
-    | search_by |
-    | css       |
-    | text       |
 
   Scenario Outline: Locating a text field using multiple parameters
     When I search for the text field by "<param1>" and "<param2>"

--- a/features/text_field.feature
+++ b/features/text_field.feature
@@ -22,7 +22,6 @@ Feature: Text Fields
     | xpath      |
     | index      |
     | title      |
-    | text       |
     | label      |
 
 
@@ -42,7 +41,7 @@ Feature: Text Fields
   Examples:
     | search_by |
     | css       |
-
+    | text       |
 
   Scenario Outline: Locating a text field using multiple parameters
     When I search for the text field by "<param1>" and "<param2>"

--- a/features/unordered_list.feature
+++ b/features/unordered_list.feature
@@ -21,17 +21,6 @@ Feature: Unordered list
     | xpath     |
     | index     |
     | name      |
-
-  @selenium_only
-  Scenario Outline: Locating unordered lists on the page
-    When I search for the unordered list by "<search_by>"
-    And I get the first item from the list
-    Then the list items text should be "Item One"
-    And the list should contain 3 items
-    And each item should contain "Item"
-
-  Scenarios:
-    | search_by |
     | css       |
 
   Scenario Outline: Locating unordered lists using multiple parameters

--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -10,7 +10,7 @@ require 'page-object/indexed_properties'
 require 'page-object/section_collection'
 require 'page-object/widgets'
 
-require 'watir-webdriver'
+require 'watir'
 require 'page-object/platforms/watir_webdriver/element'
 require 'page-object/platforms/watir_webdriver/page_object'
 require 'page-object/platforms/selenium_webdriver/element'

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -1262,7 +1262,7 @@ module PageObject
         element = self.send("#{name}_element")
 
         %w(Button TextField Radio Hidden CheckBox FileField).each do |klass|
-          next unless element.element.is_a? Object.const_get("Watir::#{klass}")
+          next unless element.element.class.to_s  == "Watir::#{klass}"
           self.class.send(klass.gsub(/(.)([A-Z])/,'\1_\2').downcase, name, identifier, &block)
           return self.send name
         end

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -196,7 +196,7 @@ module PageObject
     # @param [Hash] identifier how we find a text field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :label => Watir and Selenium
@@ -232,7 +232,7 @@ module PageObject
     # @param [Hash] identifier how we find a hidden field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -264,7 +264,7 @@ module PageObject
     # @param [Hash] identifier how we find a text area.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -300,7 +300,7 @@ module PageObject
     # @param [Hash] identifier how we find a select list.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -376,7 +376,7 @@ module PageObject
     # @param [Hash] identifier how we find a checkbox.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -416,7 +416,7 @@ module PageObject
     # @param [Hash] identifier how we find a radio button.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -591,7 +591,7 @@ module PageObject
     # @param [Hash] identifier how we find a table.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -625,7 +625,7 @@ module PageObject
     #   * :name => Watir and Selenium
     #   * :text => Watir and Selenium
     #   * :xpath => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     # @param optional block to be invoked when element method is called
     #
     def cell(name, identifier={:index => 0}, &block)
@@ -680,7 +680,7 @@ module PageObject
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :alt => Watir and Selenium
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -706,7 +706,7 @@ module PageObject
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :action => Watir and Selenium
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :xpath => Watir and Selenium
@@ -759,7 +759,7 @@ module PageObject
     # @param [Hash] identifier how we find an unordered list.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -788,7 +788,7 @@ module PageObject
     # @param [Hash] identifier how we find an ordered list.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1006,7 +1006,7 @@ module PageObject
     # @param [Hash] identifier how we find a file_field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1215,7 +1215,7 @@ module PageObject
     # @param [Hash] identifier how we find a svg.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1240,7 +1240,7 @@ module PageObject
     # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1248,21 +1248,25 @@ module PageObject
     # @param optional block to be invoked when element method is called
     #
     def element(name, tag=:element, identifier={ :index => 0 }, &block)
-      # default tag to :element
       #
-      # element 'button', css: 'some css'
-      #
-      # is the same as
-      #
-      # element 'button', :element, css: 'some css'
+      # sets tag as element if not defined
       #
       if tag.is_a?(Hash)
         identifier = tag
         tag        = :element
       end
 
+      standard_methods(name, identifier, 'element_for', &block)
+
       define_method("#{name}") do
-        self.send("#{name}_element").text
+        element = self.send("#{name}_element")
+
+        %w(Button TextField Radio Hidden CheckBox FileField).each do |klass|
+          next unless element.element.is_a? Object.const_get("Watir::#{klass}")
+          self.class.send(klass.gsub(/(.)([A-Z])/,'\1_\2').downcase, name, identifier, &block)
+          return self.send name
+        end
+        element.text
       end
       define_method("#{name}_element") do
         return call_block(&block) if block_given?
@@ -1270,6 +1274,24 @@ module PageObject
       end
       define_method("#{name}?") do
         self.send("#{name}_element").exists?
+      end
+      define_method("#{name}=") do |value|
+        element = self.send("#{name}_element")
+
+        klass = case element.element
+                when Watir::TextField
+                  'text_field'
+                when Watir::TextArea
+                  'text_area'
+                when Watir::Select
+                  'select_list'
+                when Watir::FileField
+                  'file_field'
+                else
+                  raise "Can not set a #{element.element} element with #="
+                end
+        self.class.send(klass, name, identifier, &block)
+        self.send("#{name}=", value)
       end
     end
 
@@ -1286,7 +1308,7 @@ module PageObject
     # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1294,13 +1316,8 @@ module PageObject
     # @param optional block to be invoked when element method is called
     #
     def elements(name, tag=:element, identifier={:index => 0}, &block)
-      # default tag to :element
       #
-      # elements 'button', css: 'some css'
-      #
-      # is the same as
-      #
-      # elements 'button', :element, css: 'some css'
+      # sets tag as element if not defined
       #
       if tag.is_a?(Hash)
         identifier = tag
@@ -1325,7 +1342,7 @@ module PageObject
     # @param [Hash] identifier how we find an element.  You can use multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1349,7 +1366,7 @@ module PageObject
     # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium
@@ -1376,7 +1393,7 @@ module PageObject
     # @param [Hash] identifier how we find an element.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid keys are:
     #   * :class => Watir and Selenium
-    #   * :css => Selenium only
+    #   * :css => Watir and Selenium
     #   * :id => Watir and Selenium
     #   * :index => Watir and Selenium
     #   * :name => Watir and Selenium

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -31,7 +31,7 @@ module PageObject
           the_bridge = bridge
           10.times do |n|
             color = (n % 2 == 0) ? 'red' : original_color
-            the_bridge.executeScript("arguments[0].style.backgroundColor = '#{color}'", element)
+            the_bridge.execute_script("arguments[0].style.backgroundColor = '#{color}'", element)
           end
         end
         
@@ -51,7 +51,7 @@ module PageObject
         #
         def html
           script = "return (%s).apply(null, arguments)" % ATOMS.fetch(:getOuterHtml)
-          bridge.executeScript(script, element).strip
+          bridge.execute_script(script, element).strip
         end
 
         #
@@ -119,7 +119,7 @@ module PageObject
         def fire_event(event_name)
           event_name = event_name.to_s.sub(/^on/, '').downcase
           script = "return (%s).apply(null, arguments)" % ATOMS.fetch(:fireEvent)
-          bridge.executeScript(script, element, event_name)
+          bridge.execute_script(script, element, event_name)
         end
 
         #
@@ -143,7 +143,7 @@ module PageObject
         #
         def parent
           script = "return (%s).apply(null, arguments)" % ATOMS.fetch(:getParentElement)
-          parent = bridge.executeScript(script, element)
+          parent = bridge.execute_script(script, element)
           type = element.attribute(:type).to_s.downcase if parent.tag_name.to_sym == :input
           cls = ::PageObject::Elements.element_class_for(parent.tag_name, type)
           cls.new(parent, :platform => @platform.class::PLATFORM_NAME)
@@ -153,7 +153,7 @@ module PageObject
         # Set the focus to the current element
         #
         def focus
-          bridge.executeScript("return arguments[0].focus()", element)
+          bridge.execute_script("return arguments[0].focus()", element)
         end
 
         #
@@ -162,7 +162,7 @@ module PageObject
         def select_text(text)
           Watir::Atoms.load(:selectText)
           script = "return (%s).apply(null, arguments)" % ATOMS.fetch(:selectText)
-          bridge.executeScript(script, element, text)
+          bridge.execute_script(script, element, text)
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -1,4 +1,4 @@
-require 'watir-webdriver/atoms'
+require 'watir/atoms'
 
 module PageObject
   module Platforms

--- a/lib/page-object/platforms/watir_webdriver.rb
+++ b/lib/page-object/platforms/watir_webdriver.rb
@@ -7,7 +7,7 @@ module PageObject
       end
 
       def self.is_for?(browser)
-        require 'watir-webdriver'
+        require 'watir'
         browser.is_a?(::Watir::Browser) || browser.is_a?(::Watir::HTMLElement)
       end
 

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -1,4 +1,4 @@
-require 'watir-webdriver/extensions/select_text'
+require 'watir/extensions/select_text'
 
 module PageObject
   module Platforms
@@ -27,13 +27,6 @@ module PageObject
         #
         def flash
           element.flash
-        end
-
-        #
-        # Click this element
-        #
-        def right_click
-          element.right_click
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -1,4 +1,3 @@
-require 'watir-webdriver/extensions/alerts'
 require 'page-object/elements'
 require 'page-object/core_ext/string'
 

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -1034,6 +1034,7 @@ module PageObject
         def find_watir_elements(the_call, type, identifier, tag_name=nil)
           identifier, frame_identifiers = parse_identifiers(identifier, type, tag_name)
           elements = @browser.instance_eval "#{nested_frames(frame_identifiers)}#{the_call}"
+          elements.map(&:to_subtype)
           switch_to_default_content(frame_identifiers)
           elements.map { |element| type.new(element, :platform => self.class::PLATFORM_NAME) }
         end
@@ -1041,6 +1042,7 @@ module PageObject
         def find_watir_element(the_call, type, identifier, tag_name=nil)
           identifier, frame_identifiers = parse_identifiers(identifier, type, tag_name)
           element = @browser.instance_eval "#{nested_frames(frame_identifiers)}#{the_call}"
+          element = element.to_subtype if element.exists?
           switch_to_default_content(frame_identifiers)
           type.new(element, :platform => self.class::PLATFORM_NAME)
         end

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -938,7 +938,9 @@ module PageObject
         # See PageObject::Accessors#element
         #
         def element_for(tag, identifier)
-          find_watir_element("#{tag.to_s}(identifier)", Elements::Element, identifier, tag.to_s)
+          the_call = "#{tag.to_s}(identifier)"
+          the_call << ".to_subtype" if tag.to_s == 'element'
+          find_watir_element(the_call, Elements::Element, identifier, tag.to_s)
         end
 
         #
@@ -946,7 +948,9 @@ module PageObject
         # See PageObject::Accessors#element
         #
         def elements_for(tag, identifier)
-          find_watir_elements("#{tag.to_s}s(identifier)", Elements::Element, identifier, tag.to_s)
+          the_call = "#{tag.to_s}s(identifier)"
+          the_call << ".to_subtype" if tag.to_s == 'element'
+          find_watir_elements(the_call, Elements::Element, identifier, tag.to_s)
         end
 
         #

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'watir-webdriver', '>= 0.6.11'
-  s.add_dependency 'selenium-webdriver', '>= 2.44.0'
+  s.add_dependency 'watir', ">= 6.0.0.beta5"
   s.add_dependency 'page_navigation', '>= 0.9'
   s.add_dependency 'net-http-persistent', '~> 2.9.4'
 

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -23,11 +23,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'watir-webdriver', '>= 0.6.11'
   s.add_dependency 'selenium-webdriver', '>= 2.44.0'
   s.add_dependency 'page_navigation', '>= 0.9'
+  s.add_dependency 'net-http-persistent', '~> 2.9.4'
 
   s.add_development_dependency 'rspec', '~> 3.1.0'
   s.add_development_dependency 'cucumber', '>= 1.3.0'
   s.add_development_dependency 'yard', '>= 0.7.2'
-  s.add_development_dependency 'rack', '>= 1.0'
+  s.add_development_dependency 'rack', '~> 1.0'
   s.add_development_dependency 'coveralls', '~> 0.8.1'
 
 end

--- a/spec/page-object/elements/nested_element_spec.rb
+++ b/spec/page-object/elements/nested_element_spec.rb
@@ -7,6 +7,8 @@ describe "Element with nested elements" do
     before(:each) do
       @watir_driver = Watir::Element.new(nil, {})
       @watir_element = PageObject::Elements::Element.new(@watir_driver, :platform => :watir_webdriver)
+      allow(@watir_driver).to receive(:exists?).and_return(true)
+      allow(@watir_driver).to receive(:to_subtype).and_return(@watir_driver)
     end
     
     it "should find nested links" do

--- a/spec/page-object/elements/selenium_element_spec.rb
+++ b/spec/page-object/elements/selenium_element_spec.rb
@@ -33,7 +33,7 @@ describe "Element for Selenium" do
     bridge = double('bridge')
     expect(@selenium_driver).to receive(:attribute).and_return('blue')
     expect(@selenium_driver).to receive(:instance_variable_get).and_return(bridge)
-    expect(bridge).to receive(:executeScript).exactly(10).times
+    expect(bridge).to receive(:execute_script).exactly(10).times
     @selenium_element.flash
   end
 
@@ -153,20 +153,20 @@ describe "Element for Selenium" do
 
   it "should fire an event" do
     expect(@selenium_driver).to receive(:instance_variable_get).with(:@bridge).and_return(@selenium_driver)
-    expect(@selenium_driver).to receive(:executeScript)
+    expect(@selenium_driver).to receive(:execute_script)
     @selenium_element.fire_event('onfocus')
   end
 
   it "should find the parent element" do
     expect(@selenium_driver).to receive(:instance_variable_get).with(:@bridge).and_return(@selenium_driver)
-    expect(@selenium_driver).to receive(:executeScript).and_return(@selenium_driver)
+    expect(@selenium_driver).to receive(:execute_script).and_return(@selenium_driver)
     expect(@selenium_driver).to receive(:tag_name).twice.and_return(:div)
     @selenium_element.parent
   end
 
   it "should set the focus" do
     expect(@selenium_driver).to receive(:instance_variable_get).and_return(@selenium_driver)
-    expect(@selenium_driver).to receive(:executeScript)
+    expect(@selenium_driver).to receive(:execute_script)
     @selenium_element.focus
   end
 

--- a/spec/page-object/page-object_spec.rb
+++ b/spec/page-object/page-object_spec.rb
@@ -75,7 +75,7 @@ describe PageObject do
     end
   end
 
-  context "when created with a watir-webdriver browser" do
+  context "when created with a watir browser" do
     it "should include the WatirPageObject module" do
       expect(watir_page_object.platform).to be_kind_of PageObject::Platforms::WatirWebDriver::PageObject
     end

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -243,7 +243,7 @@ describe PageObject::Accessors do
 
     it "should default elements tag to element" do
       mock_driver_for :elements
-      expect(watir_browser).to receive(:map).and_return([])
+      expect(watir_browser).to receive(:map).and_return([], [])
       page.button2_elements.to_a
     end
   end

--- a/spec/page-object/widget_spec.rb
+++ b/spec/page-object/widget_spec.rb
@@ -199,6 +199,8 @@ describe "Widget PageObject Extensions" do
       before(:each) do
         @watir_driver = Watir::Element.new(nil, {})
         @watir_element = PageObject::Elements::Element.new(@watir_driver, :platform => :watir_webdriver)
+        allow(@watir_driver).to receive(:exists?).and_return(true)
+        allow(@watir_driver).to receive(:to_subtype).and_return(@watir_driver)
       end
 
       it "should find a nested gxt_table" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ def mock_watir_browser
   watir_browser = double('watir')
   allow(watir_browser).to receive(:is_a?).with(anything()).and_return(false)
   allow(watir_browser).to receive(:is_a?).with(Watir::Browser).and_return(true)
+  allow(watir_browser).to receive(:exists?).and_return(true)
+  allow(watir_browser).to receive(:to_subtype).and_return(watir_browser)
   watir_browser
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'coveralls'
 SimpleCov.start { add_filter 'spec/' }
 
 require 'rspec'
-require 'watir-webdriver'
+require 'watir'
 require 'selenium-webdriver'
 
 require 'page-object'


### PR DESCRIPTION
Some of the css locators that were marked "Selenium Only" were already passing when I removed the @selenium_only tag, so let me know if there is another shortcoming not represented in the feature files that are needed to make this work.

This PR isn't compatible with #286, but I don't think #286 is the right solution.

As for the example in #285 which prompted it, it is not a Watir issue. Neither Selenium nor Watir give errors for the spec. The only difference between the two is a result of #279, which causes Selenium to return #value instead of #text. PageObject is what is storing it as a Button without verifying it, for both Selenium & Watir. `button.instance_variable_get('@element').wd` for Watir is the exact same object as `button.element` in Selenium. I can easily get the Watir element to be a Watir::Anchor element instead of a Watir::Button element using #to_subtype in #find_watir_element, & #find_watir_elements, but I'm not sure if that matters here since the real issue seems to be that PageObject has it wrapped incorrectly.

Either way, I don't like #286 because this: `button.exists?`  would return false for Selenium, but raise an exception for Watir, and I find that to be a bigger breaking difference.

I think it is an issue of a misunderstanding [here](https://github.com/bootstraponline/watir_example/blob/master/spec/home_page_spec.rb#L6) - One of the huge advantages of Watir (and also PageObject) is to be able to define an element object with a locator, even when there is no element at that locator on the page, yet. You should always be able to make a call: `home_page.sign_up_button_element.exists?` without it throwing an exception.
