### PR TITLE
Better support for platforms

### DIFF
--- a/lib/page-object/elements/button.rb
+++ b/lib/page-object/elements/button.rb
@@ -18,13 +18,6 @@ module PageObject
         super + [:value, :src, :alt]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/button'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::Button
-        end
-      end
     end
 
     ::PageObject::Elements.type_to_class[:submit] = ::PageObject::Elements::Button

--- a/lib/page-object/elements/check_box.rb
+++ b/lib/page-object/elements/check_box.rb
@@ -17,18 +17,6 @@ module PageObject
         super + [:value, :label, :css]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/check_box'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::CheckBox
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/check_box'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::CheckBox
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.type_to_class[:checkbox] = ::PageObject::Elements::CheckBox

--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -10,7 +10,7 @@ module PageObject
     #
     class Element
       include ::PageObject::NestedElements
-      
+
       attr_reader :element
 
       def initialize(element, platform)
@@ -40,14 +40,14 @@ module PageObject
       def disabled?
         not enabled?
       end
-      
+
       #
       # get the value of the given CSS property
       #
       def style(property)
         element.style property
       end
-      
+
       def inspect
         element.inspect
       end
@@ -97,7 +97,7 @@ module PageObject
           return how, what
         end
       end
-      
+
       # @private
       # delegate calls to driver element
       def method_missing(*args, &block)
@@ -207,20 +207,63 @@ module PageObject
       end
 
       def include_platform_for platform
-        if platform[:platform] == :watir_webdriver
-          self.class.send :include,  ::PageObject::Platforms::WatirWebDriver::Element
-          @platform = ::PageObject::Platforms::WatirWebDriver::PageObject.new(@element)
-        elsif platform[:platform] == :selenium_webdriver
-          self.class.send :include, ::PageObject::Platforms::SeleniumWebDriver::Element
-          @platform = ::PageObject::Platforms::SeleniumWebDriver::PageObject.new(@element)
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
+        platform_information = PageObject::Platforms.get
+        raise ArgumentError,"Expected hash with at least a key :platform for platform information! (#{platform.inspect})" unless platform.class == Hash && platform.has_key?(:platform)
+        platform_name = platform[:platform]
+
+        raise ArgumentError, "Unknown platform #{platform_name}! Expect platform to be one of the following: #{platform_information.keys.inspect}" unless platform_information.keys.include?(platform_name)
+        base_platform_class = "#{platform_information[platform_name]}::"
+
+        self.send :extend, constantize_classname(base_platform_class + "Element")
+        @platform = constantize_classname(base_platform_class+ "PageObject").new(@element)
+
+        # include class specific code
+        class_to_include = case
+                             when self.class ==  PageObject::Elements::Element
+                               # already loaded
+                               return true
+                             when self.class.name =~/PageObject:Elements::/
+                               self.class
+                               # inherited classes for example the widgets
+                             else
+                               parent_classes = self.class.ancestors.select { |item| item.name =~/PageObject::Elements::/ }
+                               raise RuntimeError,"Could not identify page-object inherited class for #{self.class}!" if parent_classes.empty?
+                               parent_classes.first
+                           end
+
+        element_type_specific_code = File.expand_path(File.dirname(__FILE__) + "../../platforms/#{platform_name}/"+ get_element_type_underscored(class_to_include) )
+        if File.exist? element_type_specific_code + '.rb'
+          require element_type_specific_code
+          self.send :extend, constantize_classname( base_platform_class + get_element_type(class_to_include) )
         end
+
       end
 
       def to_ary
         nil
       end
+
+      private
+
+
+      def constantize_classname name
+        name.split("::").inject(Object) { |k,n| k.const_get(n) }
+      end
+
+
+      def get_element_type(class_name = self.class)
+        class_name.name.split('::').last
+      end
+
+      # retrieved from ruby on rails underscore method
+      def get_element_type_underscored(class_name = self.class)
+        get_element_type(class_name).to_s.gsub(/::/, '/').
+         gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+         gsub(/([a-z\d])([A-Z])/,'\1_\2').
+         tr("-", "_").
+         downcase
+      end
+
     end
   end
 end

--- a/lib/page-object/elements/file_field.rb
+++ b/lib/page-object/elements/file_field.rb
@@ -18,18 +18,6 @@ module PageObject
         super + [:title, :label]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/file_field'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::FileField
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/file_field'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::FileField
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.type_to_class[:file] = ::PageObject::Elements::FileField

--- a/lib/page-object/elements/form.rb
+++ b/lib/page-object/elements/form.rb
@@ -17,18 +17,6 @@ module PageObject
         super + [:action]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/form'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::Form
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/form'
-          self.class.send :include,  PageObject::Platforms::SeleniumWebDriver::Form
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.tag_to_class[:form] = ::PageObject::Elements::Form

--- a/lib/page-object/elements/image.rb
+++ b/lib/page-object/elements/image.rb
@@ -16,18 +16,6 @@ module PageObject
         super + [:alt, :src, :css]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/image'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::Image
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/image'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::Image
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.tag_to_class[:img] = ::PageObject::Elements::Image

--- a/lib/page-object/elements/link.rb
+++ b/lib/page-object/elements/link.rb
@@ -26,18 +26,6 @@ module PageObject
         super.merge(:text => :link_text)
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/link'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::Link
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/link'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::Link
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
     
     ::PageObject::Elements.tag_to_class[:a] = ::PageObject::Elements::Link

--- a/lib/page-object/elements/ordered_list.rb
+++ b/lib/page-object/elements/ordered_list.rb
@@ -30,19 +30,6 @@ module PageObject
         [:class, :id, :index, :xpath]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/ordered_list'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::OrderedList
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/ordered_list'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::OrderedList
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
-
     end
 
     ::PageObject::Elements.tag_to_class[:ol] = ::PageObject::Elements::OrderedList

--- a/lib/page-object/elements/radio_button.rb
+++ b/lib/page-object/elements/radio_button.rb
@@ -18,18 +18,6 @@ module PageObject
         super + [:value, :label]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/radio_button'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::RadioButton
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/radio_button'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::RadioButton
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.type_to_class[:radio] = ::PageObject::Elements::RadioButton

--- a/lib/page-object/elements/select_list.rb
+++ b/lib/page-object/elements/select_list.rb
@@ -22,19 +22,6 @@ module PageObject
         super + [:label]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/select_list'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::SelectList
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/select_list'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::SelectList
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
-
     end
 
     ::PageObject::Elements.tag_to_class[:select] = ::PageObject::Elements::SelectList

--- a/lib/page-object/elements/table.rb
+++ b/lib/page-object/elements/table.rb
@@ -59,19 +59,6 @@ module PageObject
         ::PageObject::Elements::TableRow.new(row_element, platform)
       end
 
-
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/table'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::Table
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/table'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::Table
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.tag_to_class[:table] = ::PageObject::Elements::Table

--- a/lib/page-object/elements/table_row.rb
+++ b/lib/page-object/elements/table_row.rb
@@ -30,19 +30,6 @@ module PageObject
         ::PageObject::Elements::TableCell.new(row_element, platform)
       end
 
-
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/table_row'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::TableRow
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/table_row'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::TableRow
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.tag_to_class[:tr] = ::PageObject::Elements::TableRow

--- a/lib/page-object/elements/text_area.rb
+++ b/lib/page-object/elements/text_area.rb
@@ -16,20 +16,6 @@ module PageObject
         super + [:label]
       end
 
-      protected
-
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/text_area'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::TextArea
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/text_area'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::TextArea
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.tag_to_class[:textarea] = ::PageObject::Elements::TextArea

--- a/lib/page-object/elements/text_field.rb
+++ b/lib/page-object/elements/text_field.rb
@@ -22,18 +22,6 @@ module PageObject
         super + [:title, :value, :text, :label]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/text_field'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::TextField
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/text_field'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::TextField
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.type_to_class[:text] = ::PageObject::Elements::TextField

--- a/lib/page-object/elements/unordered_list.rb
+++ b/lib/page-object/elements/unordered_list.rb
@@ -31,18 +31,6 @@ module PageObject
         [:class, :id, :index, :xpath]
       end
 
-      def include_platform_for platform
-        super
-        if platform[:platform] == :watir_webdriver
-          require 'page-object/platforms/watir_webdriver/unordered_list'
-          self.class.send :include, PageObject::Platforms::WatirWebDriver::UnorderedList
-        elsif platform[:platform] == :selenium_webdriver
-          require 'page-object/platforms/selenium_webdriver/unordered_list'
-          self.class.send :include, PageObject::Platforms::SeleniumWebDriver::UnorderedList
-        else
-          raise ArgumentError, "expect platform to be :watir_webdriver or :selenium_webdriver"
-        end
-      end
     end
 
     ::PageObject::Elements.tag_to_class[:ul] = ::PageObject::Elements::UnorderedList

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -146,7 +146,7 @@ module PageObject
           parent = bridge.executeScript(script, element)
           type = element.attribute(:type).to_s.downcase if parent.tag_name.to_sym == :input
           cls = ::PageObject::Elements.element_class_for(parent.tag_name, type)
-          cls.new(parent, :platform => :selenium_webdriver)
+          cls.new(parent, :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/ordered_list.rb
+++ b/lib/page-object/platforms/selenium_webdriver/ordered_list.rb
@@ -24,7 +24,7 @@ module PageObject
 
         def children
           items = list_items.map do |item|
-            ::PageObject::Elements::ListItem.new(item, :platform => :selenium_webdriver)
+            ::PageObject::Elements::ListItem.new(item, :platform => @platform.class::PLATFORM_NAME)
           end
           items.find_all { |item| item.parent.element == element }
         end

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -12,6 +12,12 @@ module PageObject
       # and use the methods dynamically added from the PageObject::Accessors module.
       #
       class PageObject
+
+        def self.define_widget_accessors(widget_tag, widget_class, base_element_tag)
+          define_widget_singular_accessor(base_element_tag, widget_class, widget_tag)
+          define_widget_multiple_accessor(base_element_tag, widget_class, widget_tag)
+        end
+
         def initialize(browser)
           @browser = browser
         end
@@ -1231,6 +1237,19 @@ module PageObject
             end
           end
         end
+
+        def self.define_widget_multiple_accessor(base_element_tag, widget_class, widget_tag)
+          send(:define_method, "#{widget_tag}s_for") do |identifier|
+            find_selenium_elements(identifier, widget_class, base_element_tag)
+          end
+        end
+
+        def self.define_widget_singular_accessor(base_element_tag, widget_class, widget_tag)
+          send(:define_method, "#{widget_tag}_for") do |identifier|
+            find_selenium_element(identifier, widget_class, base_element_tag)
+          end
+        end
+
       end
     end
   end

--- a/lib/page-object/platforms/selenium_webdriver/page_object.rb
+++ b/lib/page-object/platforms/selenium_webdriver/page_object.rb
@@ -13,6 +13,8 @@ module PageObject
       #
       class PageObject
 
+        PLATFORM_NAME = :selenium_webdriver
+
         def self.define_widget_accessors(widget_tag, widget_class, base_element_tag)
           define_widget_singular_accessor(base_element_tag, widget_class, widget_tag)
           define_widget_multiple_accessor(base_element_tag, widget_class, widget_tag)
@@ -145,7 +147,7 @@ module PageObject
           element = @browser.execute_script("return document.activeElement")
           type = element.attribute(:type).to_s.downcase if element.tag_name.to_sym == :input
           cls = ::PageObject::Elements.element_class_for(element.tag_name, type)
-          cls.new(element, :platform => :selenium_webdriver)
+          cls.new(element, :platform => self.class::PLATFORM_NAME)
         end
 
         #
@@ -1101,7 +1103,7 @@ module PageObject
             return build_null_object(identifier, type, tag, other)
           end
           @browser.switch_to.default_content unless frame_identifiers.nil?
-          type.new(element, :platform => :selenium_webdriver)
+          type.new(element, :platform => self.class::PLATFORM_NAME)
         end
 
         def find_selenium_elements(identifier, type, tag, other=nil)
@@ -1115,7 +1117,7 @@ module PageObject
             elements = eles.find_all {|ele| matches_selector?(ele, regexp[0], regexp[1])}
           end
           @browser.switch_to.default_content unless frame_identifiers.nil?
-          elements.map { |element| type.new(element, :platform => :selenium_webdriver) }
+          elements.map { |element| type.new(element, :platform => self.class::PLATFORM_NAME) }
         end
 
         def find_selenium_pages(identifier, page_class)
@@ -1159,7 +1161,7 @@ module PageObject
           null_element.tag = tag
           null_element.other = other
           null_element.platform = self
-          Elements::Element.new(null_element, :platform => :selenium_webdriver)
+          Elements::Element.new(null_element, :platform => self.class::PLATFORM_NAME)
         end
 
         def delete_regexp(identifier)

--- a/lib/page-object/platforms/selenium_webdriver/select_list.rb
+++ b/lib/page-object/platforms/selenium_webdriver/select_list.rb
@@ -38,7 +38,7 @@ module PageObject
         #
         # @return [array of PageObject::Elements::Option]
         def options
-          find_options.map { |e| ::PageObject::Elements::Option.new(e, :platform => :selenium_webdriver) }
+          find_options.map { |e| ::PageObject::Elements::Option.new(e, :platform => @platform.class::PLATFORM_NAME) }
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/table.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table.rb
@@ -14,7 +14,7 @@ module PageObject
           eles = table_rows
           idx = find_index_by_title(idx, eles) if idx.kind_of?(String)
           return nil unless idx
-          initialize_row(eles[idx], :platform => :selenium_webdriver)
+          initialize_row(eles[idx], :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/table_row.rb
+++ b/lib/page-object/platforms/selenium_webdriver/table_row.rb
@@ -14,7 +14,7 @@ module PageObject
           els = table_cells
           idx = find_index_by_title(idx) if idx.kind_of?(String)
           return nil unless idx  && columns >= idx + 1
-          initialize_cell(els[idx], :platform => :selenium_webdriver)
+          initialize_cell(els[idx], :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/unordered_list.rb
+++ b/lib/page-object/platforms/selenium_webdriver/unordered_list.rb
@@ -24,7 +24,7 @@ module PageObject
 
         def children
           items = list_items.map do |item|
-            ::PageObject::Elements::ListItem.new(item, :platform => :selenium_webdriver)
+            ::PageObject::Elements::ListItem.new(item, :platform => @platform.class::PLATFORM_NAME)
           end
           items.find_all { |item| item.parent.element == element }
         end

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -28,7 +28,14 @@ module PageObject
         def flash
           element.flash
         end
-        
+
+        #
+        # Click this element
+        #
+        def right_click
+          element.right_click
+        end
+
         #
         # Get the text for the element
         #

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -141,7 +141,7 @@ module PageObject
           parent = element.parent
           type = element.type if parent.tag_name.to_sym == :input
           cls = ::PageObject::Elements.element_class_for(parent.tag_name, type)
-          cls.new(parent, :platform => :watir_webdriver)
+          cls.new(parent, :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/ordered_list.rb
+++ b/lib/page-object/platforms/watir_webdriver/ordered_list.rb
@@ -10,7 +10,7 @@ module PageObject
         # @return [PageObject::Elements::ListItem]
         #
         def [](idx)
-          Object::PageObject::Elements::ListItem.new(children[idx], :platform => :watir_webdriver)
+          Object::PageObject::Elements::ListItem.new(children[idx], :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -14,6 +14,13 @@ module PageObject
       class PageObject
         attr_reader :browser
 
+
+
+        def self.define_widget_accessors(widget_tag, widget_class, base_element_tag)
+        define_widget_singular_accessor(base_element_tag, widget_class, widget_tag)
+        define_widget_multiple_accessor(base_element_tag, widget_class, widget_tag)
+        end
+
         def initialize(browser)
           @browser = browser
         end
@@ -1091,6 +1098,18 @@ module PageObject
               @browser.wd.switch_to.frame(value)
             end
           end          
+        end
+
+        def self.define_widget_multiple_accessor(base_element_tag, widget_class, widget_tag)
+          send(:define_method, "#{widget_tag}s_for") do |identifier|
+            find_watir_elements("#{base_element_tag}s(identifier)", widget_class, identifier, base_element_tag)
+          end
+        end
+
+        def self.define_widget_singular_accessor(base_element_tag, widget_class, widget_tag)
+          send(:define_method, "#{widget_tag}_for") do |identifier|
+            find_watir_element("#{base_element_tag}(identifier)", widget_class, identifier, base_element_tag)
+          end
         end
       end
     end

--- a/lib/page-object/platforms/watir_webdriver/page_object.rb
+++ b/lib/page-object/platforms/watir_webdriver/page_object.rb
@@ -6,6 +6,7 @@ require 'page-object/core_ext/string'
 module PageObject
   module Platforms
     module WatirWebDriver
+
       #
       # Watir implementation of the page object platform driver.  You should not use the
       # class directly.  Instead you should include the PageObject module in your page object
@@ -14,7 +15,7 @@ module PageObject
       class PageObject
         attr_reader :browser
 
-
+        PLATFORM_NAME = :watir_webdriver
 
         def self.define_widget_accessors(widget_tag, widget_class, base_element_tag)
         define_widget_singular_accessor(base_element_tag, widget_class, widget_tag)
@@ -139,7 +140,7 @@ module PageObject
           element = browser.execute_script("return document.activeElement")
           type = element.type.to_sym if element.tag_name.to_sym == :input
           cls = ::PageObject::Elements.element_class_for(element.tag_name, type)
-          cls.new(element, :platform => :watir_webdriver)    
+          cls.new(element, :platform => self.class::PLATFORM_NAME)
         end
 
         #
@@ -1007,14 +1008,14 @@ module PageObject
           identifier, frame_identifiers = parse_identifiers(identifier, type, tag_name)
           elements = @browser.instance_eval "#{nested_frames(frame_identifiers)}#{the_call}"
           switch_to_default_content(frame_identifiers)
-          elements.map { |element| type.new(element, :platform => :watir_webdriver) }
+          elements.map { |element| type.new(element, :platform => self.class::PLATFORM_NAME) }
         end
 
         def find_watir_element(the_call, type, identifier, tag_name=nil)
           identifier, frame_identifiers = parse_identifiers(identifier, type, tag_name)
           element = @browser.instance_eval "#{nested_frames(frame_identifiers)}#{the_call}"
           switch_to_default_content(frame_identifiers)
-          type.new(element, :platform => :watir_webdriver)
+          type.new(element, :platform => self.class::PLATFORM_NAME)
         end
 
         def find_watir_pages(identifier, page_class)

--- a/lib/page-object/platforms/watir_webdriver/select_list.rb
+++ b/lib/page-object/platforms/watir_webdriver/select_list.rb
@@ -34,7 +34,7 @@ module PageObject
         # @return [array of PageObject::Elements::Option]
         #
         def options
-          element.options.map { |e| ::PageObject::Elements::Option.new(e, :platform => :watir_webdriver) }
+          element.options.map { |e| ::PageObject::Elements::Option.new(e, :platform => @platform.class::PLATFORM_NAME) }
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/table.rb
+++ b/lib/page-object/platforms/watir_webdriver/table.rb
@@ -14,7 +14,7 @@ module PageObject
         def [](idx)
           idx = find_index_by_title(idx) if idx.kind_of?(String)
           return nil unless idx
-          initialize_row(element[idx], :platform => :watir_webdriver)
+          initialize_row(element[idx], :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/table_row.rb
+++ b/lib/page-object/platforms/watir_webdriver/table_row.rb
@@ -12,7 +12,7 @@ module PageObject
         def [](idx)
           idx = find_index_by_title(idx) if idx.kind_of?(String)
           return nil unless idx && columns >= idx + 1
-          initialize_cell(element[idx], :platform => :watir_webdriver)
+          initialize_cell(element[idx], :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/unordered_list.rb
+++ b/lib/page-object/platforms/watir_webdriver/unordered_list.rb
@@ -10,7 +10,7 @@ module PageObject
         # @return [PageObject::Elements::ListItem]
         #
         def [](idx)
-          Object::PageObject::Elements::ListItem.new(children[idx], :platform => :watir_webdriver)
+          Object::PageObject::Elements::ListItem.new(children[idx], :platform => @platform.class::PLATFORM_NAME)
         end
 
         #

--- a/spec/page-object/elements/select_list_spec.rb
+++ b/spec/page-object/elements/select_list_spec.rb
@@ -43,12 +43,12 @@ describe PageObject::Elements::SelectList do
       let(:watir_sel_list) { PageObject::Elements::SelectList.new(sel_list, :platform => :watir_webdriver) }
 
       it "should return an option when indexed" do
-        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(sel_list).to receive(:options).with(no_args).and_return(opts)
         expect(watir_sel_list[0]).to be_instance_of PageObject::Elements::Option
       end
 
       it "should return an array of options" do
-        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(sel_list).to receive(:options).with(no_args).and_return(opts)
         expect(watir_sel_list.options.size).to eql 2
       end
 

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -253,6 +253,7 @@ describe PageObject::Accessors do
 
     def mock_driver_for(tag)
       expect(watir_browser).to receive(tag).with(:index => 0).and_return(watir_browser)
+      allow(watir_browser).to receive(:exists?).with(no_args)
     end
 
     it "should work with a text_field" do


### PR DESCRIPTION
Pull request as follow-up of  https://github.com/cheezy/page-object/pull/265

As suggested I tried creating a seperate gem to support watir nokogiri (https://github.com/pvmeerbe/page_object_watir_nokogiri), however the current implementation is limited/hardcoded for selenium & watir platforms only on some spots.

I made some modifications to allow easy addition of new platforms + allow easy inheritance of the existing platforms, for example WatirNokogiri platform inherits from Watir platform (see commit descriptions)

Spec & feature tests now provide same result as current master tree  (test on Feature: Gxt Table Extension fails as the related web site http://gxtexamplegallery.appspot.com/ is not available anymore) + new version of page object was tested on existing test suite using selenium-webdriver & watirnokogiri


