### PR TITLE
Fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # page-object
 
-[![Gem Version](https://badge.fury.io/rb/page-object.svg)](http://badge.fury.io/rb/page-object)
+[![Gem Version](https://badge.fury.io/rb/page-object.svg)](https://rubygems.org/gems/page-object)
 [![Build Status](https://travis-ci.org/cheezy/page-object.png)](https://travis-ci.org/cheezy/page-object)
-[![Coverage Status](https://coveralls.io/repos/bootstraponline/page_object/badge.svg?nocache)](https://coveralls.io/r/cheezy/page_object)
+[![Coverage Status](https://coveralls.io/repos/cheezy/page-object/badge.svg?nocache)](https://coveralls.io/r/cheezy/page-object)
 
 
 A simple gem that assists in creating flexible page objects for testing browser based applications. The goal is to facilitate creating abstraction layers in your tests to decouple the tests from the item they are testing and to provide a simple interface to the elements on a page. It works with both watir-webdriver and selenium-webdriver.


### PR DESCRIPTION
The gem badge should link directly to https rubygems (not via badge fury http redirect).

The coverage status is wrong. It's pointing to `page_object` which is my fork of `page-object`. I'm actively maintaining a fork with extra bug fixes / features so the coverage info on my fork will differ from upstream.