### PR TITLE
Add Ruby 2.2.3 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.3
   - jruby-19mode
 
 before_script:


### PR DESCRIPTION
Ruby 2.2.3 is the current stable release so I think the tests should support it.