### PR TITLE
Omit coveralls formatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,11 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'simplecov'
 require 'coveralls'
+
+# Omit coveralls formatter since we're merging suite results via a Rake task
+# https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails
+SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
+
 SimpleCov.start { add_filter 'spec/' }
 
 require 'rspec'


### PR DESCRIPTION
I had this fix in my [fork from June](https://github.com/bootstraponline/page_object/commit/e8b66d3b633f484a10495087cb11b74577139535). In [merging multiple test suites](https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails) coveralls.io mentions having to omit the formatter when using the rake task to send the coverage so I think this change is required.