### PR TITLE
Forward visibility checks to root

### DIFF
--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -49,6 +49,10 @@ module PageObject
   include LoadsPlatform
   include ElementLocators
   include PagePopulator
+  extend Forwardable
+
+  # Forward visibility checks to root so page sections can be tested for existence.
+  def_delegators :root, :visible?, :present?, :exists?
 
   # @return [Watir::Browser or Selenium::WebDriver::Driver] the platform browser passed to the constructor
   attr_reader :browser


### PR DESCRIPTION
This PR extends PageObject with Forwardable and forwards :visible?, :present?, :exists? to the root element.  This allows for a natural syntax:

```
page.some_section.visible?
```