### PR TITLE
Added right_click method for watir and location and size methods for watir and selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-=== Version 1.0.3 / 2014-12-8
+=== Version 1.0.3 / 2014-12-9
 * Enhancements
   * Added support for the bold tag (Thanks sedx)
   * Added support for angularjs in wait_for_ajax (Thanks Owen Housden)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+=== Version 1.0.4
+* Enhancements
+  * Performance enhancements when initializing elements (Thanks Dane Andersen)
+
 === Version 1.0.3 / 2014-12-9
 * Enhancements
   * Added support for the bold tag (Thanks sedx)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # page-object
 
+[![Gem Version](https://badge.fury.io/rb/page-object.svg)](http://badge.fury.io/rb/page-object)
 [![Build Status](https://travis-ci.org/cheezy/page-object.png)](https://travis-ci.org/cheezy/page-object)
+[![Coverage Status](https://coveralls.io/repos/bootstraponline/page_object/badge.svg?nocache)](https://coveralls.io/r/cheezy/page_object)
 
 
 A simple gem that assists in creating flexible page objects for testing browser based applications. The goal is to facilitate creating abstraction layers in your tests to decouple the tests from the item they are testing and to provide a simple interface to the elements on a page. It works with both watir-webdriver and selenium-webdriver.

--- a/features/element.feature
+++ b/features/element.feature
@@ -320,3 +320,24 @@ Feature: Elements
 
   Scenario: Selecting the text for an element
     Then I should be able to select "Elements" from the paragraph
+
+  Scenario: Getting the horizontal location of an element
+    When I retrieve a link element
+    Then the horizontal element location is not 0
+
+  Scenario: Getting the vertical location of an element
+    When I retrieve a link element
+    And the vertical element location is not 0
+
+  Scenario: Getting the height of an element
+    When I retrieve a link element
+    Then the element height is not 0
+
+  Scenario: Getting the width of an element
+    When I retrieve a link element
+    Then the element width is not 0
+
+  Scenario: Getting the centre of an element
+    When I retrieve a button element
+    Then the element centre should be greater than element y position
+    And the element centre should be greater than element x position

--- a/features/gxt_table_extension.feature
+++ b/features/gxt_table_extension.feature
@@ -8,7 +8,6 @@ Feature: Gxt Table Extension
     And I have registered the GxtTable with PageObject
     And I define a page-object using that widget
     And I am on the Gxt Examples page
-    And I have the Basic Grid opened
 
   Scenario: Retrieve a GxtTable
     When I retrieve a GxtTable widget
@@ -21,4 +20,4 @@ Feature: Gxt Table Extension
 
   Scenario: Confirm a correct row count from a GxtTable
     When I retrieve a GxtTable widget
-    Then the GxtTable should have "13" rows
+    Then the GxtTable should have "3" rows

--- a/features/html/widgets.html
+++ b/features/html/widgets.html
@@ -1,0 +1,20 @@
+<html>
+<body>
+<div class="x-grid3">
+    <table>
+        <tr>
+            <th>Column1</th>
+            <th>Column2</th>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>2</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>4</td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/features/step_definitions/async_steps.rb
+++ b/features/step_definitions/async_steps.rb
@@ -79,5 +79,5 @@ end
 
 Then /^I should not be able to find the button$/ do
   @page.created_button_element.when_not_present
-  @page.created_button_element.exists?.should be_false
+  @page.created_button_element.exists?.should be false
 end

--- a/features/step_definitions/check_box_steps.rb
+++ b/features/step_definitions/check_box_steps.rb
@@ -3,7 +3,7 @@ When /^I select the First check box$/ do
 end
 
 Then /^the First check box should be selected$/ do
-  @page.cb_id_checked?.should be_true
+  @page.cb_id_checked?.should be true
 end
 
 When /^I unselect the First check box$/ do
@@ -11,7 +11,7 @@ When /^I unselect the First check box$/ do
 end
 
 Then /^the First check box should not be selected$/ do
-  @page.cb_id_checked?.should be_false
+  @page.cb_id_checked?.should be false
 end
 
 When /^I search for the check box by "([^\"]*)"$/ do |how|

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -266,26 +266,27 @@ Then(/^I should know the attribute "(.*?)" includes "(.+)"$/) do |attribute, inc
 end
 
 Then(/the horizontal element location is not 0/) do
-  @element.location_x.should > 0
+  @element.location['x'].should > 0
 end
 
 Then(/the vertical element location is not 0/) do
-  @element.location_y.should > 0
+  @element.location['y'].should > 0
 end
 
 Then(/the element height is not 0/) do
+  (@element.height.is_a? Integer).should ==true
   @element.height.should > 0
 end
 
 Then(/the element width is not 0/) do
-  @element.width.should > 0
   (@element.width.is_a? Integer).should ==true
+  @element.width.should > 0
 end
 
 Then(/the element centre should be greater than element y position/) do
-  @element.centre['y'].should > @element.location_y
+  @element.centre['y'].should > @element.location['y']
 end
 
 Then(/the element centre should be greater than element x position/) do
-  @element.centre['x'].should > @element.location_x
+  @element.centre['x'].should > @element.location['x']
 end

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -264,3 +264,28 @@ Then(/^I should know the attribute "(.*?)" includes "(.+)"$/) do |attribute, inc
   @attr = @element.attribute(attribute)
   @attr.should include included
 end
+
+Then(/the horizontal element location is not 0/) do
+  @element.location_x.should > 0
+end
+
+Then(/the vertical element location is not 0/) do
+  @element.location_y.should > 0
+end
+
+Then(/the element height is not 0/) do
+  @element.height.should > 0
+end
+
+Then(/the element width is not 0/) do
+  @element.width.should > 0
+  (@element.width.is_a? Integer).should ==true
+end
+
+Then(/the element centre should be greater than element y position/) do
+  @element.centre['y'].should > @element.location_y
+end
+
+Then(/the element centre should be greater than element x position/) do
+  @element.centre['x'].should > @element.location_x
+end

--- a/features/step_definitions/gxt_table_steps.rb
+++ b/features/step_definitions/gxt_table_steps.rb
@@ -12,10 +12,6 @@ Given /^I am on the Gxt Examples page$/ do
   visit GxtSamplePageObject
 end
 
-When /^I have the Basic Grid opened$/ do
-  on(GxtSamplePageObject).basic_grid_element.click
-end
-
 When /^I have defined a GxtTable class extending Table$/ do
   class GxtTable < PageObject::Elements::Table
 
@@ -36,9 +32,8 @@ When /^I define a page-object using that widget$/ do
   class GxtSamplePageObject
     include PageObject
 
-    page_url "http://gxtexamplegallery.appspot.com/"
+    page_url UrlHelper.widgets
 
-    div(:basic_grid, :class => "label_basic_grid") 
     gxt_table(:gxt_table, :class => "x-grid3")
   end unless class_exists? 'GxtSamplePageObject'
 end

--- a/features/step_definitions/label_steps.rb
+++ b/features/step_definitions/label_steps.rb
@@ -15,5 +15,5 @@ When /^I get the text from a label while the script is executing$/ do
 end
 
 Then /^I should see that the label exists$/ do
-  @page.label_id?.should be_true
+  @page.label_id?.should be true
 end

--- a/features/step_definitions/multi_elements_steps.rb
+++ b/features/step_definitions/multi_elements_steps.rb
@@ -528,7 +528,7 @@ When(/^I select the multiple elements with a tag label$/) do
   @elements = @page.generic_label_elements
 end
 
-When /^I select the bs"$/ do
+When /^I select the bs$/ do
   @elements = @page.b_elements
 end
 

--- a/features/step_definitions/select_list_steps.rb
+++ b/features/step_definitions/select_list_steps.rb
@@ -40,7 +40,7 @@ Then /^the select list should include "([^\"]*)"$/ do |text|
 end
 
 Then /^the select list should know that "([^\"]*)" is selected$/ do |text|
-  @page.sel_list_id_element.selected?(text).should be_true
+  @page.sel_list_id_element.selected?(text).should be true
 end
 
 Then /^the value for the option should be "([^\"]*)"$/ do |value|

--- a/features/support/url_helper.rb
+++ b/features/support/url_helper.rb
@@ -53,5 +53,9 @@ module UrlHelper
     def double_click
       "#{files}/double_click.html"
     end
+
+    def widgets
+      "#{files}/widgets.html"
+    end
   end
 end

--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -9,6 +9,7 @@ require 'page-object/javascript_framework_facade'
 require 'page-object/indexed_properties'
 require 'page-object/widgets'
 
+require 'watir-webdriver'
 require 'page-object/platforms/watir_webdriver/element'
 require 'page-object/platforms/watir_webdriver/page_object'
 require 'page-object/platforms/selenium_webdriver/element'

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -307,8 +307,7 @@ module PageObject
         def centre
           location = element.location
           size = element.size
-          centre = {'y' => (location['y'] + (size['height']/2)), 'x' => (location['x'] + (size['width']/2))}
-          centre
+          {'y' => (location['y'] + (size['height']/2)), 'x' => (location['x'] + (size['width']/2))}
         end
 
         private

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -283,15 +283,8 @@ module PageObject
         #
         # Get vertical location of element
         #
-        def location_y
-          element.location['y']
-        end
-
-        #
-        # Get horizontal location of element
-        #
-        def location_x
-          element.location['x']
+        def location
+          element.location
         end
 
         #

--- a/lib/page-object/platforms/selenium_webdriver/element.rb
+++ b/lib/page-object/platforms/selenium_webdriver/element.rb
@@ -280,6 +280,44 @@ module PageObject
           element.location_once_scrolled_into_view
         end
 
+        #
+        # Get vertical location of element
+        #
+        def location_y
+          element.location['y']
+        end
+
+        #
+        # Get horizontal location of element
+        #
+        def location_x
+          element.location['x']
+        end
+
+        #
+        # Get height of element
+        #
+        def height
+          element.size['height']
+        end
+
+        #
+        # Get width of element
+        #
+        def width
+          element.size['width']
+        end
+
+        #
+        # Get centre coordinates of element
+        #
+        def centre
+          location = element.location
+          size = element.size
+          centre = {'y' => (location['y'] + (size['height']/2)), 'x' => (location['x'] + (size['width']/2))}
+          centre
+        end
+
         private
 
         def bridge

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -249,17 +249,10 @@ module PageObject
         end
 
         #
-        # Get vertical location of element
+        # Get location of element
         #
-        def location_y
-          element.wd.location['y']
-        end
-
-        #
-        # Get horizontal location of element
-        #
-        def location_x
-          element.wd.location['x']
+        def location
+          element.wd.location
         end
 
         #

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -275,8 +275,7 @@ module PageObject
         def centre
           location = element.wd.location
           size = element.wd.size
-          centre = {'y' => (location['y'] + (size['height']/2)), 'x' => (location['x'] + (size['width']/2))}
-          centre
+          {'y' => (location['y'] + (size['height']/2)), 'x' => (location['x'] + (size['width']/2))}
         end
       end
     end

--- a/lib/page-object/platforms/watir_webdriver/element.rb
+++ b/lib/page-object/platforms/watir_webdriver/element.rb
@@ -150,7 +150,11 @@ module PageObject
         def select_text(text)
           element.select_text text
         end
-        
+
+        def right_click
+          element.right_click
+        end
+
         #
         # Waits until the element is present
         #
@@ -242,6 +246,44 @@ module PageObject
         #
         def scroll_into_view
           element.wd.location_once_scrolled_into_view
+        end
+
+        #
+        # Get vertical location of element
+        #
+        def location_y
+          element.wd.location['y']
+        end
+
+        #
+        # Get horizontal location of element
+        #
+        def location_x
+          element.wd.location['x']
+        end
+
+        #
+        # Get height of element
+        #
+        def height
+          element.wd.size['height']
+        end
+
+        #
+        # Get width of element
+        #
+        def width
+          element.wd.size['width']
+        end
+
+        #
+        # Get centre coordinates of element
+        #
+        def centre
+          location = element.wd.location
+          size = element.wd.size
+          centre = {'y' => (location['y'] + (size['height']/2)), 'x' => (location['x'] + (size['width']/2))}
+          centre
         end
       end
     end

--- a/spec/page-object/element_locators_spec.rb
+++ b/spec/page-object/element_locators_spec.rb
@@ -12,700 +12,699 @@ describe PageObject::ElementLocators do
     let(:watir_page_object) { ElementLocatorsTestPageObject.new(watir_browser) }
     
     it "should find a button element" do
-      watir_browser.should_receive(:button).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:button).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.button_element(:id => 'blah')
       expect(element).to  be_instance_of PageObject::Elements::Button
     end
 
     it "should find a button element using a default identifier" do
-      watir_browser.should_receive(:button).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:button).with(:index => 0).and_return(watir_browser)
       watir_page_object.button_element
     end
 
     it "should find all button elements" do
-      watir_browser.should_receive(:buttons).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:buttons).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.button_elements(:id => 'blah')
       expect(elements[0]).to  be_instance_of PageObject::Elements::Button
     end
 
     it "should find all buttons with no identifier" do
-      watir_browser.should_receive(:buttons).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:buttons).with({}).and_return([watir_browser])
       watir_page_object.button_elements
     end
     
     it "should find a text field element" do
-      watir_browser.should_receive(:text_field).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:text_field).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.text_field_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::TextField
     end
 
     it "should find a text field element using a default identifier" do
-      watir_browser.should_receive(:text_field).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:text_field).with(:index => 0).and_return(watir_browser)
       watir_page_object.text_field_element
     end
 
     it "should find all text field elements" do
-      watir_browser.should_receive(:text_fields).with(:id => 'blah').and_return([watir_browser])
-      watir_browser.should_receive(:tag_name).and_return('input')
+      expect(watir_browser).to receive(:text_fields).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:tag_name).and_return('input')
       elements = watir_page_object.text_field_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::TextField
     end
 
     it "should find all text fields with no identifier" do
-      watir_browser.should_receive(:text_fields).with({}).and_return([watir_browser])
-      watir_browser.should_receive(:tag_name).and_return('input')
+      expect(watir_browser).to receive(:text_fields).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:tag_name).and_return('input')
       watir_page_object.text_field_elements
     end
     
     it "should find a hidden field element" do
-      watir_browser.should_receive(:hidden).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:hidden).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.hidden_field_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::HiddenField
     end
 
     it "should find a hidden field using a default identifier" do
-      watir_browser.should_receive(:hidden).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:hidden).with(:index => 0).and_return(watir_browser)
       watir_page_object.hidden_field_element
     end
 
     it "should find all hidden field elements" do
-      watir_browser.should_receive(:hiddens).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:hiddens).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.hidden_field_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of(PageObject::Elements::HiddenField)
     end
 
     it "should find all hidden field elements using no identifier" do
-      watir_browser.should_receive(:hiddens).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:hiddens).with({}).and_return([watir_browser])
       watir_page_object.hidden_field_elements
     end
     
     it "should find a text area element" do
-      watir_browser.should_receive(:textarea).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:textarea).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.text_area_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::TextArea
     end
 
     it "should find a text area using a default identifier" do
-      watir_browser.should_receive(:textarea).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:textarea).with(:index => 0).and_return(watir_browser)
       watir_page_object.text_area_element
     end
 
     it "should find all text area elements" do
-      watir_browser.should_receive(:textareas).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:textareas).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.text_area_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::TextArea 
     end
 
     it "should find all text area elements using no identifier" do
-      watir_browser.should_receive(:textareas).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:textareas).with({}).and_return([watir_browser])
       watir_page_object.text_area_elements
     end
     
     it "should find a select list element" do
-      watir_browser.should_receive(:select_list).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:select_list).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.select_list_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::SelectList
     end
 
     it "should find a select list using a default identifier" do
-      watir_browser.should_receive(:select_list).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:select_list).with(:index => 0).and_return(watir_browser)
       watir_page_object.select_list_element
     end
 
     it "should find all select list elements" do
-      watir_browser.should_receive(:select_lists).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:select_lists).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.select_list_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::SelectList 
     end
 
     it "should find all select list elements using no identifier" do
-      watir_browser.should_receive(:select_lists).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:select_lists).with({}).and_return([watir_browser])
       watir_page_object.select_list_elements
     end
     
     it "should find a link element" do
-      watir_browser.should_receive(:link).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:link).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.link_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Link
     end
 
     it "should find a link element using a default identifier" do
-      watir_browser.should_receive(:link).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:link).with(:index => 0).and_return(watir_browser)
       watir_page_object.link_element
     end
 
     it "should find all link elements" do
-      watir_browser.should_receive(:links).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:links).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.link_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Link 
     end
 
     it "should find all links using no identifier" do
-      watir_browser.should_receive(:links).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:links).with({}).and_return([watir_browser])
       watir_page_object.link_elements
     end
     
     it "should find a check box" do
-      watir_browser.should_receive(:checkbox).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:checkbox).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.checkbox_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::CheckBox
     end
 
     it "should find a check box using a default identifier" do
-      watir_browser.should_receive(:checkbox).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:checkbox).with(:index => 0).and_return(watir_browser)
       watir_page_object.checkbox_element
     end
 
     it "should find all check box elements" do
-      watir_browser.should_receive(:checkboxes).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:checkboxes).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.checkbox_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::CheckBox 
     end
 
     it "should find all check box elements using no identifier" do
-      watir_browser.should_receive(:checkboxes).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:checkboxes).with({}).and_return([watir_browser])
       watir_page_object.checkbox_elements
     end
     
     it "should find a radio button" do
-      watir_browser.should_receive(:radio).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:radio).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.radio_button_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::RadioButton
     end
 
     it "should find a radio button using a default identifier" do
-      watir_browser.should_receive(:radio).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:radio).with(:index => 0).and_return(watir_browser)
       watir_page_object.radio_button_element
     end
 
     it "should find all radio buttons" do
-      watir_browser.should_receive(:radios).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:radios).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.radio_button_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::RadioButton 
     end
 
     it "should find all radio buttons using no identifier" do
-      watir_browser.should_receive(:radios).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:radios).with({}).and_return([watir_browser])
       watir_page_object.radio_button_elements
     end
     
     it "should find a div" do
-      watir_browser.should_receive(:div).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:div).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.div_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Div
     end
 
     it "should find a div using a default identifier" do
-      watir_browser.should_receive(:div).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:div).with(:index => 0).and_return(watir_browser)
       watir_page_object.div_element
     end
 
     it "should find all div elements" do
-      watir_browser.should_receive(:divs).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:divs).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.div_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Div 
     end
 
     it "should find all div elements using no identifier" do
-      watir_browser.should_receive(:divs).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:divs).with({}).and_return([watir_browser])
       watir_page_object.div_elements
     end
     
     it "should find a span" do
-      watir_browser.should_receive(:span).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:span).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.span_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Span
     end
 
     it "should find a span using a default identifier" do
-      watir_browser.should_receive(:span).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:span).with(:index => 0).and_return(watir_browser)
       watir_page_object.span_element
     end
 
     it "should find all span elements" do
-      watir_browser.should_receive(:spans).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:spans).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.span_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Span 
     end
 
     it "should find all span elements using no identifier" do
-      watir_browser.should_receive(:spans).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:spans).with({}).and_return([watir_browser])
       watir_page_object.span_elements
     end
     
     it "should find a table" do
-      watir_browser.should_receive(:table).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:table).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.table_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Table
     end
 
     it "should find a table using a default identifier" do
-      watir_browser.should_receive(:table).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:table).with(:index => 0).and_return(watir_browser)
       watir_page_object.table_element
     end
 
     it "should find all table elements" do
-      watir_browser.should_receive(:tables).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:tables).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.table_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Table 
     end
 
     it "should find all table elements using no identifier" do
-      watir_browser.should_receive(:tables).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:tables).with({}).and_return([watir_browser])
       watir_page_object.table_elements
     end
     
     it "should find a table cell" do
-      watir_browser.should_receive(:td).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:td).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.cell_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::TableCell
     end
 
     it "should find a table cell using a default identifier" do
-      watir_browser.should_receive(:td).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:td).with(:index => 0).and_return(watir_browser)
       watir_page_object.cell_element
     end
 
     it "should find all table cells" do
-      watir_browser.should_receive(:tds).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:tds).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.cell_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::TableCell 
     end
 
     it "should find all table cells using no identifier" do
-      watir_browser.should_receive(:tds).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:tds).with({}).and_return([watir_browser])
       watir_page_object.cell_elements
     end
     
     it "should find an image" do
-      watir_browser.should_receive(:image).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:image).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.image_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Image
     end
 
     it "should find an image using a default identifier" do
-      watir_browser.should_receive(:image).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:image).with(:index => 0).and_return(watir_browser)
       watir_page_object.image_element
     end
 
     it "should find all images" do
-      watir_browser.should_receive(:images).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:images).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.image_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Image
     end
 
     it "should find all images using no identifier" do
-      watir_browser.should_receive(:images).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:images).with({}).and_return([watir_browser])
       watir_page_object.image_elements
     end
     
     it "should find a form" do
-      watir_browser.should_receive(:form).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:form).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.form_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Form
     end
 
     it "should find a form using a default identifier" do
-      watir_browser.should_receive(:form).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:form).with(:index => 0).and_return(watir_browser)
       watir_page_object.form_element
     end
 
     it "should find all forms" do
-      watir_browser.should_receive(:forms).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:forms).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.form_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Form
     end
 
     it "should find all forms using no identifier" do
-      watir_browser.should_receive(:forms).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:forms).with({}).and_return([watir_browser])
       watir_page_object.form_elements
     end
     
     it "should find a list item" do
-      watir_browser.should_receive(:li).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:li).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.list_item_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::ListItem
     end
 
     it "should find a list item using a default identifier" do
-      watir_browser.should_receive(:li).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:li).with(:index => 0).and_return(watir_browser)
       watir_page_object.list_item_element
     end
 
     it "should find all list items" do
-      watir_browser.should_receive(:lis).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:lis).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.list_item_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::ListItem 
     end
 
     it "should find all list items using no parameter" do
-      watir_browser.should_receive(:lis).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:lis).with({}).and_return([watir_browser])
       watir_page_object.list_item_elements
     end
     
     it "should find an unordered list" do
-      watir_browser.should_receive(:ul).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:ul).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.unordered_list_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::UnorderedList
     end
 
     it "should find an unordered list using a default identifier" do
-      watir_browser.should_receive(:ul).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:ul).with(:index => 0).and_return(watir_browser)
       watir_page_object.unordered_list_element
     end
 
     it "should find all unordered lists" do
-      watir_browser.should_receive(:uls).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:uls).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.unordered_list_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::UnorderedList 
     end
 
     it "should find all unordered lists using no parameters" do
-      watir_browser.should_receive(:uls).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:uls).with({}).and_return([watir_browser])
       watir_page_object.unordered_list_elements
     end
     
     it "should find an ordered list" do
-      watir_browser.should_receive(:ol).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:ol).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.ordered_list_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::OrderedList
     end
 
     it "should find an orderd list using a default identifier" do
-      watir_browser.should_receive(:ol).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:ol).with(:index => 0).and_return(watir_browser)
       watir_page_object.ordered_list_element
     end
 
     it "should find all ordered lists" do
-      watir_browser.should_receive(:ols).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:ols).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.ordered_list_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::OrderedList 
     end
 
     it "should find all orderd lists using no parameters" do
-      watir_browser.should_receive(:ols).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:ols).with({}).and_return([watir_browser])
       watir_page_object.ordered_list_elements
     end
     
     it "should find a h1 element" do
-      watir_browser.should_receive(:h1).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:h1).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.h1_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h1 element using a default identifier" do
-      watir_browser.should_receive(:h1).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:h1).with(:index => 0).and_return(watir_browser)
       watir_page_object.h1_element
     end
 
     it "should find all h1 elements" do
-      watir_browser.should_receive(:h1s).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:h1s).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.h1_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find all h1 elements using no parameters" do
-      watir_browser.should_receive(:h1s).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:h1s).with({}).and_return([watir_browser])
       watir_page_object.h1_elements
     end
 
     it "should find a h2 element" do
-      watir_browser.should_receive(:h2).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:h2).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.h2_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h2 element using default identifier" do
-      watir_browser.should_receive(:h2).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:h2).with(:index => 0).and_return(watir_browser)
       watir_page_object.h2_element
     end
 
     it "should find all h2 elements" do
-      watir_browser.should_receive(:h2s).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:h2s).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.h2_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find all h2 elements using no identifier" do
-      watir_browser.should_receive(:h2s).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:h2s).with({}).and_return([watir_browser])
       watir_page_object.h2_elements
     end
 
     it "should find a h3 element" do
-      watir_browser.should_receive(:h3).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:h3).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.h3_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h3 element using a default identifier" do
-      watir_browser.should_receive(:h3).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:h3).with(:index => 0).and_return(watir_browser)
       watir_page_object.h3_element
     end
 
     it "should find all h3 elements" do
-      watir_browser.should_receive(:h3s).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:h3s).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.h3_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find all h3 elements using no identifiers" do
-      watir_browser.should_receive(:h3s).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:h3s).with({}).and_return([watir_browser])
       watir_page_object.h3_elements
     end
 
     it "should find a h4 element" do
-      watir_browser.should_receive(:h4).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:h4).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.h4_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h4 element using a default identifier" do
-      watir_browser.should_receive(:h4).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:h4).with(:index => 0).and_return(watir_browser)
       watir_page_object.h4_element
     end
 
     it "should find all h4 elements" do
-      watir_browser.should_receive(:h4s).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:h4s).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.h4_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find all h4 elements using no identifier" do
-      watir_browser.should_receive(:h4s).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:h4s).with({}).and_return([watir_browser])
       watir_page_object.h4_elements
     end
 
     it "should find a h5 element" do
-      watir_browser.should_receive(:h5).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:h5).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.h5_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h5 element using a default identifier" do
-      watir_browser.should_receive(:h5).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:h5).with(:index => 0).and_return(watir_browser)
       watir_page_object.h5_element
     end
 
     it "should find all h5 elements" do
-      watir_browser.should_receive(:h5s).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:h5s).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.h5_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find all h5 elements using no identifier" do
-      watir_browser.should_receive(:h5s).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:h5s).with({}).and_return([watir_browser])
       watir_page_object.h5_elements
     end
 
     it "should find a h6 element" do
-      watir_browser.should_receive(:h6).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:h6).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.h6_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h6 element using a default identifier" do
-      watir_browser.should_receive(:h6).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:h6).with(:index => 0).and_return(watir_browser)
       watir_page_object.h6_element
     end
 
     it "should find all h6 elements" do
-      watir_browser.should_receive(:h6s).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:h6s).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.h6_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find all h6 elements using no identifier" do
-      watir_browser.should_receive(:h6s).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:h6s).with({}).and_return([watir_browser])
       watir_page_object.h6_elements
     end
 
     it "should find a paragraph element" do
-      watir_browser.should_receive(:p).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:p).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.paragraph_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Paragraph
     end
 
     it "should find a paragraph element using a default identifier" do
-      watir_browser.should_receive(:p).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:p).with(:index => 0).and_return(watir_browser)
       watir_page_object.paragraph_element
     end
 
     it "should find all paragraph elements" do
-      watir_browser.should_receive(:ps).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:ps).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.paragraph_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Paragraph 
     end
 
     it "should find all paragraph elements using no identifier" do
-      watir_browser.should_receive(:ps).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:ps).with({}).and_return([watir_browser])
       watir_page_object.paragraph_elements
     end
 
     it "should find a label" do
-      watir_browser.should_receive(:label).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:label).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.label_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Label
     end
 
     it "should find a label element using default parameters" do
-      watir_browser.should_receive(:label).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:label).with(:index => 0).and_return(watir_browser)
       watir_page_object.label_element
     end
 
     it "should find all label elements" do
-      watir_browser.should_receive(:labels).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:labels).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.label_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Label
     end
 
     it "should find all label elements using no parameters" do
-      watir_browser.should_receive(:labels).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:labels).with({}).and_return([watir_browser])
       watir_page_object.label_elements
     end
 
     it "should find a file field element" do
-      watir_browser.should_receive(:file_field).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:file_field).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.file_field_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::FileField
     end
 
     it "should find a file field element using a default identifier" do
-      watir_browser.should_receive(:file_field).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:file_field).with(:index => 0).and_return(watir_browser)
       watir_page_object.file_field_element
     end
 
     it "should find all file field elements" do
-      watir_browser.should_receive(:file_fields).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:file_fields).with(:id => 'blah').and_return([watir_browser])
       element = watir_page_object.file_field_elements(:id => 'blah')
       expect(element[0]).to be_instance_of PageObject::Elements::FileField
     end
 
     it "should find all file fields using no identifier" do
-      watir_browser.should_receive(:file_fields).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:file_fields).with({}).and_return([watir_browser])
       watir_page_object.file_field_elements
     end
 
     it "should find an area element" do
-      watir_browser.should_receive(:area).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:area).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.area_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Area
     end
 
     it "should find an area element using a default identifier" do
-      watir_browser.should_receive(:area).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:area).with(:index => 0).and_return(watir_browser)
       watir_page_object.area_element
     end
 
     it "should find all area elements" do
-      watir_browser.should_receive(:areas).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:areas).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.area_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Area
     end
 
     it "should find all areas with no identifier" do
-      watir_browser.should_receive(:areas).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:areas).with({}).and_return([watir_browser])
       watir_page_object.area_elements
     end
     
     it "should find a canvas element" do
-      watir_browser.should_receive(:canvas).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:canvas).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.canvas_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Canvas
     end
 
     it "should find a canvas element using a default identifier" do
-      watir_browser.should_receive(:canvas).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:canvas).with(:index => 0).and_return(watir_browser)
       watir_page_object.canvas_element
     end
 
     it "should find all canvas elements" do
-      watir_browser.should_receive(:canvases).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:canvases).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.canvas_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Canvas
     end
 
     it "should find all canvases with no identifier" do
-      watir_browser.should_receive(:canvases).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:canvases).with({}).and_return([watir_browser])
       watir_page_object.canvas_elements
     end
 
     it "should find an audio element" do
-      watir_browser.should_receive(:audio).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:audio).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.audio_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Audio
     end
 
     it "should find an audio element using a default identifier" do
-      watir_browser.should_receive(:audio).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:audio).with(:index => 0).and_return(watir_browser)
       watir_page_object.audio_element
     end
 
     it "should find all audio elements" do
-      watir_browser.should_receive(:audios).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:audios).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.audio_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Audio
     end
 
     it "should find all audio elements with no identifier" do
-      watir_browser.should_receive(:audios).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:audios).with({}).and_return([watir_browser])
       watir_page_object.audio_elements
     end
 
     it "should find a video element" do
-      watir_browser.should_receive(:video).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:video).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.video_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Video
     end
 
     it "should find a video element using a default identifier" do
-      watir_browser.should_receive(:video).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:video).with(:index => 0).and_return(watir_browser)
       watir_page_object.video_element
     end
 
     it "should find all video elements" do
-      watir_browser.should_receive(:videos).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:videos).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.video_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Video
     end
 
     it "should find all video elements with no identifier" do
-      watir_browser.should_receive(:videos).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:videos).with({}).and_return([watir_browser])
       watir_page_object.video_elements
     end
 
     it "should find an element" do
-      watir_browser.should_receive(:audio).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:audio).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.element(:audio, :id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Element
     end
 
     it "should find an element using a default identifier" do
-      watir_browser.should_receive(:audio).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:audio).with(:index => 0).and_return(watir_browser)
       watir_page_object.element(:audio)
     end
 
     it "should find a b element" do
-      watir_browser.should_receive(:b).with(:id => 'blah').and_return(watir_browser)
+      expect(watir_browser).to receive(:b).with(:id => 'blah').and_return(watir_browser)
       element = watir_page_object.b_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Bold
     end
 
     it "should find a b element using a default identifier" do
-      watir_browser.should_receive(:b).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(:b).with(:index => 0).and_return(watir_browser)
       watir_page_object.b_element
     end
 
     it "should find all b elements" do
-      watir_browser.should_receive(:bs).with(:id => 'blah').and_return([watir_browser])
+      expect(watir_browser).to receive(:bs).with(:id => 'blah').and_return([watir_browser])
       elements = watir_page_object.b_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Bold
     end
 
     it "should find all b elements using no parameters" do
-      watir_browser.should_receive(:bs).with({}).and_return([watir_browser])
+      expect(watir_browser).to receive(:bs).with({}).and_return([watir_browser])
       watir_page_object.b_elements
     end
-
   end
 
   context "when using Selenium" do
@@ -713,386 +712,386 @@ describe PageObject::ElementLocators do
     let(:selenium_page_object) { ElementLocatorsTestPageObject.new(selenium_browser) }
     
     it "should find a button element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.button_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Button
     end
 
     it "should find all button elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.button_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Button
     end
 
     it "should find a text field element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.text_field_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::TextField
     end
 
     it "should find all text field elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.text_field_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::TextField
     end
 
     it "should find a hidden field element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.hidden_field_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::HiddenField
     end
 
     it "should find all hidden field elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, "blah").and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, "blah").and_return([selenium_browser])
       elements = selenium_page_object.hidden_field_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::HiddenField 
 
     end
     
     it "should find a text area element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.text_area_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::TextArea
     end
 
     it "should find all text area elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.text_area_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::TextArea 
     end
     
     it "should find a select list element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.select_list_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::SelectList
     end
 
     it "should find all select list elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.select_list_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::SelectList 
     end
     
     it "should find a link element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.link_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Link
     end
 
     it "should find all link elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.link_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Link 
     end
     
     it "should find a check box" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.checkbox_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::CheckBox
     end
 
     it "should find all checkbox elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.checkbox_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::CheckBox 
     end
     
     it "should find a radio button" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.radio_button_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::RadioButton
     end
 
     it "should find all radio button elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.radio_button_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::RadioButton 
     end
     
     it "should find a div" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.div_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Div
     end
 
     it "should find all div elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.div_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Div 
     end
     
     it "should find a span" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.span_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Span
     end
 
     it "should find all span elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.span_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Span 
     end
     
     it "should find a table" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.table_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Table
     end
     
     it "should find all table elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.table_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Table 
     end
     
     it "should find a table cell" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.cell_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::TableCell
     end
 
     it "should find all table cell elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.cell_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::TableCell 
     end
 
     it "should find an image" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.image_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Image
     end
 
     it "should find all image elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.image_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Image
     end
     
     it "should find a form" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.form_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Form
     end
     
     it "should find all forms" do
-       selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+       expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
        elements = selenium_page_object.form_elements(:id => 'blah')
        expect(elements[0]).to be_instance_of PageObject::Elements::Form
     end
 
     it "should find a list item" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.list_item_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::ListItem
     end
 
     it "should find all list items" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       element = selenium_page_object.list_item_elements(:id => 'blah')
       expect(element[0]).to be_instance_of PageObject::Elements::ListItem 
     end
     
     it "should find an unordered list" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.unordered_list_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::UnorderedList
     end
 
     it "should find all unordered lists" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.unordered_list_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::UnorderedList 
     end
     
     it "should find an ordered list" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.ordered_list_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::OrderedList
     end
 
     it "should find all orderd list elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.ordered_list_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::OrderedList 
     end
     
     it "should find a h1 element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.h1_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find all h1 elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, "blah").and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, "blah").and_return([selenium_browser])
       elements = selenium_page_object.h1_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find a h2 element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.h2_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find all h2 elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.h2_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find a h3 element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.h3_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find all h3 elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.h3_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find a h4 element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.h4_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find all h4 elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.h4_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find a h5 element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.h5_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find all h5 elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.h5_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find a h6 element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.h6_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
 
     it "should find all h6 elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.h6_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Heading 
     end
 
     it "should find a paragraph element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.paragraph_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Paragraph
     end
 
     it "should find all paragraph elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.paragraph_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Paragraph 
     end
 
     it "should find a label" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.label_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Label
     end
 
     it "should find all label elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.label_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Label
     end    
 
     it "should find a file field element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.file_field_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::FileField
     end
 
         it "should find an area element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.area_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Area
     end
 
     it "should find an area element using a default identifier" do
-      selenium_browser.should_receive(:find_element).with(:xpath, '(.//area)[1]').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:xpath, '(.//area)[1]').and_return(selenium_browser)
       selenium_page_object.area_element
     end
 
     it "should find all area elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.area_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Area
     end
 
     it "should find all areas with no identifier" do
-      selenium_browser.should_receive(:find_elements).with(:tag_name, 'area').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:tag_name, 'area').and_return([selenium_browser])
       selenium_page_object.area_elements
     end
 
     it "should find a canvas element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.canvas_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Canvas
     end
 
     it "should find a canvas element using a default identifier" do
-      selenium_browser.should_receive(:find_element).with(:xpath, '(.//canvas)[1]').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:xpath, '(.//canvas)[1]').and_return(selenium_browser)
       selenium_page_object.canvas_element
     end
 
     it "should find all canvas elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.canvas_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Canvas
     end
 
     it "should find all canvases with no identifier" do
-      selenium_browser.should_receive(:find_elements).with(:tag_name, 'canvas').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:tag_name, 'canvas').and_return([selenium_browser])
       selenium_page_object.canvas_elements
     end
 
     it "should find an audio element" do
-      selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
       element = selenium_page_object.audio_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Audio
     end
 
     it "should find an audio element using a default identifier" do
-      selenium_browser.should_receive(:find_element).with(:xpath, '(.//audio)[1]').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:xpath, '(.//audio)[1]').and_return(selenium_browser)
       selenium_page_object.audio_element
     end
 
     it "should find all audio elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.audio_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Audio
     end
 
     it "should find all audio elements with no identifier" do
-      selenium_browser.should_receive(:find_elements).with(:tag_name, 'audio').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:tag_name, 'audio').and_return([selenium_browser])
       selenium_page_object.audio_elements
     end
     it "should find a b element" do
-      selenium_browser.should_receive(:find_element).with(:id,'blah').and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).with(:id,'blah').and_return(selenium_browser)
       element = selenium_page_object.b_element(:id => 'blah')
       expect(element).to be_instance_of PageObject::Elements::Bold
     end
 
 
     it "should find all b elements" do
-      selenium_browser.should_receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
+      expect(selenium_browser).to receive(:find_elements).with(:id, 'blah').and_return([selenium_browser])
       elements = selenium_page_object.b_elements(:id => 'blah')
       expect(elements[0]).to be_instance_of PageObject::Elements::Bold
     end

--- a/spec/page-object/elements/area_spec.rb
+++ b/spec/page-object/elements/area_spec.rb
@@ -27,17 +27,17 @@ describe PageObject::Elements::Area do
       let(:selenium_area) { PageObject::Elements::Area.new(area_element, :platform => :selenium_webdriver) }
       
       it "should know its coords" do
-        area_element.should_receive(:attribute).with(:coords).and_return("1,2,3,4")
+        expect(area_element).to receive(:attribute).with(:coords).and_return("1,2,3,4")
         expect(selenium_area.coords).to eql "1,2,3,4"
       end
 
       it "should know its shape" do
-        area_element.should_receive(:attribute).with(:shape).and_return('circle')
+        expect(area_element).to receive(:attribute).with(:shape).and_return('circle')
         expect(selenium_area.shape).to eql 'circle'
       end
 
       it "should know its href" do
-        area_element.should_receive(:attribute).with(:href).and_return('twitter.com')
+        expect(area_element).to receive(:attribute).with(:href).and_return('twitter.com')
         expect(selenium_area.href).to eql 'twitter.com'
       end
     end

--- a/spec/page-object/elements/canvas_spec.rb
+++ b/spec/page-object/elements/canvas_spec.rb
@@ -27,12 +27,12 @@ describe PageObject::Elements::Canvas do
       let(:selenium_canvas) { PageObject::Elements::Canvas.new(canvas_element, :platform => :selenium_webdriver) }
 
       it "should know its width" do
-        canvas_element.should_receive(:attribute).with(:width).and_return("400")
+        expect(canvas_element).to receive(:attribute).with(:width).and_return("400")
         expect(selenium_canvas.width).to eql 400
       end
 
       it "should know its height" do
-        canvas_element.should_receive(:attribute).with(:height).and_return("100")
+        expect(canvas_element).to receive(:attribute).with(:height).and_return("100")
         expect(selenium_canvas.height).to eql 100
       end
     end

--- a/spec/page-object/elements/check_box_spec.rb
+++ b/spec/page-object/elements/check_box_spec.rb
@@ -29,19 +29,19 @@ describe PageObject::Elements::CheckBox do
     
     context "for selenium" do
       it "should check" do
-        check_box.should_receive(:click)
-        check_box.should_receive(:selected?).and_return(false)
+        expect(check_box).to receive(:click)
+        expect(check_box).to receive(:selected?).and_return(false)
         selenium_cb.check
       end
 
       it "should uncheck" do
-        check_box.should_receive(:click)
-        check_box.should_receive(:selected?).and_return(true)
+        expect(check_box).to receive(:click)
+        expect(check_box).to receive(:selected?).and_return(true)
         selenium_cb.uncheck
       end
       
       it "should know if it is checked" do
-        check_box.should_receive(:selected?).and_return(true)
+        expect(check_box).to receive(:selected?).and_return(true)
         expect(selenium_cb).to be_checked
       end
     end

--- a/spec/page-object/elements/element_spec.rb
+++ b/spec/page-object/elements/element_spec.rb
@@ -82,32 +82,32 @@ describe "Element" do
     let(:element) { PageObject::Elements::Element.new(native, :platform => :watir_webdriver) }
 
     it "should check if native is enabled" do
-      native.should_receive(:enabled?).and_return(true)
+      expect(native).to receive(:enabled?).and_return(true)
       expect(element).to be_enabled
     end
 
     it "should click the native" do
-      native.should_receive(:click)
+      expect(native).to receive(:click)
       element.click
     end
 
     it "should double click the native" do
-      native.should_receive(:double_click)
+      expect(native).to receive(:double_click)
       element.double_click
     end
 
     it "should inspect the native" do
-      native.should_receive(:inspect)
+      expect(native).to receive(:inspect)
       element.inspect
     end
 
     it "should retrieve the native's style" do
-      native.should_receive(:style).with('foo').and_return("cheezy_style")
+      expect(native).to receive(:style).with('foo').and_return("cheezy_style")
       expect(element.style('foo')).to eql 'cheezy_style'
     end
 
     it "should know if a native is disabled" do
-      native.should_receive(:enabled?).and_return(false)
+      expect(native).to receive(:enabled?).and_return(false)
       expect(element).to be_disabled
     end
   end

--- a/spec/page-object/elements/file_field_spec.rb
+++ b/spec/page-object/elements/file_field_spec.rb
@@ -31,7 +31,7 @@ describe PageObject::Elements::FileField do
     context "for selenium" do
       it "should set its' value" do
         selenium_file_field = PageObject::Elements::FileField.new(filefield, :platform => :selenium_webdriver)
-        filefield.should_receive(:send_keys).with('a file')
+        expect(filefield).to receive(:send_keys).with('a file')
         selenium_file_field.value = 'a file'
       end
     end

--- a/spec/page-object/elements/form_spec.rb
+++ b/spec/page-object/elements/form_spec.rb
@@ -12,7 +12,7 @@ describe PageObject::Elements::Form do
     context "for watir" do
       it "should submit a form" do
         form = PageObject::Elements::Form.new(form_element, :platform => :watir_webdriver)
-        form_element.should_receive(:submit)
+        expect(form_element).to receive(:submit)
         form.submit
       end
     end
@@ -20,7 +20,7 @@ describe PageObject::Elements::Form do
     context "for selenium" do
       it "should submit a form" do
         form = PageObject::Elements::Form.new(form_element, :platform => :selenium_webdriver)
-        form_element.should_receive(:submit)
+        expect(form_element).to receive(:submit)
         form.submit
       end
     end

--- a/spec/page-object/elements/image_spec.rb
+++ b/spec/page-object/elements/image_spec.rb
@@ -24,7 +24,7 @@ describe PageObject::Elements::Image do
     let(:image_element) { double('image_element') }
 
     before(:each) do
-      image_element.stub(:size).and_return(image_element)
+      allow(image_element).to receive(:size).and_return(image_element)
     end
 
     it "should register with tag_name :img" do
@@ -34,13 +34,13 @@ describe PageObject::Elements::Image do
     context "for watir" do
       it "should know the images width" do
         image = PageObject::Elements::Image.new(image_element, :platform => :watir_webdriver)
-        image_element.should_receive(:width).and_return(100)
+        expect(image_element).to receive(:width).and_return(100)
         expect(image.width).to eql 100
       end
 
       it "should know the images height" do
         image = PageObject::Elements::Image.new(image_element, :platform => :watir_webdriver)
-        image_element.should_receive(:height).and_return(120)
+        expect(image_element).to receive(:height).and_return(120)
         expect(image.height).to eql 120
       end
     end
@@ -49,16 +49,16 @@ describe PageObject::Elements::Image do
       it "should know the images width" do
         dim = double('dimension')
         image = PageObject::Elements::Image.new(image_element, :platform => :selenium_webdriver)
-        image_element.should_receive(:size).and_return(dim)
-        dim.should_receive(:width).and_return(100)
+        expect(image_element).to receive(:size).and_return(dim)
+        expect(dim).to receive(:width).and_return(100)
         expect(image.width).to eql 100
       end
 
       it "should know the images height" do
         dim = double('dimension')
         image = PageObject::Elements::Image.new(image_element, :platform => :selenium_webdriver)
-        image_element.should_receive(:size).and_return(dim)
-        dim.should_receive(:height).and_return(120)
+        expect(image_element).to receive(:size).and_return(dim)
+        expect(dim).to receive(:height).and_return(120)
         expect(image.height).to eql 120
       end
     end

--- a/spec/page-object/elements/nested_element_spec.rb
+++ b/spec/page-object/elements/nested_element_spec.rb
@@ -10,117 +10,117 @@ describe "Element with nested elements" do
     end
     
     it "should find nested links" do
-      @watir_driver.should_receive(:link).with(:id => 'blah').and_return(@watir_driver)
+      expect(@watir_driver).to receive(:link).with(:id => 'blah').and_return(@watir_driver)
       @watir_element.link_element(:id => 'blah')
     end
 
     it "should find nested buttons" do
-      @watir_driver.should_receive(:button).with(:id => 'blah').and_return(@watir_driver)
+      expect(@watir_driver).to receive(:button).with(:id => 'blah').and_return(@watir_driver)
       @watir_element.button_element(:id => 'blah')
     end
     
     it "should find nested text fields" do
-      @watir_driver.should_receive(:text_field).with(:id => 'blah').and_return(@watir_driver)
+      expect(@watir_driver).to receive(:text_field).with(:id => 'blah').and_return(@watir_driver)
       @watir_element.text_field_element(:id => 'blah')
     end
 
     it "should find nested hidden fields" do
-      @watir_driver.should_receive(:hidden).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:hidden).and_return(@watir_driver)
       @watir_element.hidden_field_element
     end
 
     it "should find nested text areas" do
-      @watir_driver.should_receive(:textarea).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:textarea).and_return(@watir_driver)
       @watir_element.text_area_element
     end
 
     it "should find a nested select list" do
-      @watir_driver.should_receive(:select_list).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:select_list).and_return(@watir_driver)
       @watir_element.select_list_element
     end
 
     it "should find a nested checkbox" do
-      @watir_driver.should_receive(:checkbox).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:checkbox).and_return(@watir_driver)
       @watir_element.checkbox_element
     end
     
     it "should find a nested radio button" do
-      @watir_driver.should_receive(:radio).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:radio).and_return(@watir_driver)
       @watir_element.radio_button_element
     end
     
     it "should find a nested div" do
-      @watir_driver.should_receive(:div).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:div).and_return(@watir_driver)
       @watir_element.div_element
     end
     
     it "should find a nested span" do
-      @watir_driver.should_receive(:span).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:span).and_return(@watir_driver)
       @watir_element.span_element
     end
     
     it "should find a nested table" do
-      @watir_driver.should_receive(:table).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:table).and_return(@watir_driver)
       @watir_element.table_element
     end
 
     it "should find a nested cell" do
-      @watir_driver.should_receive(:td).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:td).and_return(@watir_driver)
       @watir_element.cell_element
     end
     
     it "should find a nested image" do
-      @watir_driver.should_receive(:image).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:image).and_return(@watir_driver)
       @watir_element.image_element
     end
     
     it "should find a nested form" do
-      @watir_driver.should_receive(:form).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:form).and_return(@watir_driver)
       @watir_element.form_element
     end
     
     it "should find a nested ordered list" do
-      @watir_driver.should_receive(:ol).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:ol).and_return(@watir_driver)
       @watir_element.ordered_list_element
     end
     
     it "should find a nested unordered list" do
-      @watir_driver.should_receive(:ul).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:ul).and_return(@watir_driver)
       @watir_element.unordered_list_element
     end
     
     it "should find a nested list item" do
-      @watir_driver.should_receive(:li).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:li).and_return(@watir_driver)
       @watir_element.list_item_element
     end
     
     it "should find a nested h1" do
-      @watir_driver.should_receive(:h1).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:h1).and_return(@watir_driver)
       @watir_element.h1_element
     end
 
     it "should find a nested h2" do
-      @watir_driver.should_receive(:h2).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:h2).and_return(@watir_driver)
       @watir_element.h2_element
     end
 
     it "should find a nested h3" do
-      @watir_driver.should_receive(:h3).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:h3).and_return(@watir_driver)
       @watir_element.h3_element
     end
 
     it "should find a nested h4" do
-      @watir_driver.should_receive(:h4).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:h4).and_return(@watir_driver)
       @watir_element.h4_element
     end
 
     it "should find a nested h5" do
-      @watir_driver.should_receive(:h5).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:h5).and_return(@watir_driver)
       @watir_element.h5_element
     end
 
     it "should find a nested h6" do
-      @watir_driver.should_receive(:h6).and_return(@watir_driver)
+      expect(@watir_driver).to receive(:h6).and_return(@watir_driver)
       @watir_element.h6_element
     end
   end
@@ -132,122 +132,122 @@ describe "Element with nested elements" do
     end
 
     it "should find nested links" do
-      @selenium_driver.should_receive(:find_element).with(:id, 'blah').and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).with(:id, 'blah').and_return(@selenium_driver)
       @selenium_element.link_element(:id => 'blah')
     end
 
     it "should find nested buttons" do
-      @selenium_driver.should_receive(:find_element).with(:id, 'blah').and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).with(:id, 'blah').and_return(@selenium_driver)
       @selenium_element.button_element(:id => 'blah')
     end
     
     it "should find nested text fields" do
-      @selenium_driver.should_receive(:find_element).with(:id, 'blah').and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).with(:id, 'blah').and_return(@selenium_driver)
       @selenium_element.text_field_element(:id => 'blah')
     end
     
     it "should find nested hidden fields" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.hidden_field_element
     end
     
     it "should find nested text areas" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.text_area_element
     end
     
     it "should find a nested select list" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.select_list_element
     end
     
     it "should find a nested checkbox" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.checkbox_element
     end
     
     it "should find a nested radio button" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.radio_button_element
     end
     
     it "should find a nested div" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.div_element
     end
     
     it "should find a nested span" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.span_element
     end
     
     it "should find a nested table" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.table_element
     end
 
     it "should find a nested cell" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.cell_element
     end
     
     it "should find a nested image" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.image_element
     end
     
     it "should find a nested form" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.form_element
     end
     
     it "should find an ordered list" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.ordered_list_element
     end
     
     it "should find an unordered list" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.unordered_list_element
     end
     
     it "should find a nested list item" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.list_item_element
     end
     
     it "should find a nested h1" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.h1_element
     end
     
     it "should find a nested h2" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.h2_element
     end
 
     it "should find a nested h3" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.h3_element
     end
 
     it "should find a nested h4" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.h4_element
     end
 
     it "should find a nested h5" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.h5_element
     end
 
     it "should find a nested h6" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.h6_element
     end
 
     it "should find a nested paragraph" do
-      @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+      expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
       @selenium_element.paragraph_element
     end
   end

--- a/spec/page-object/elements/ordered_list_spec.rb
+++ b/spec/page-object/elements/ordered_list_spec.rb
@@ -67,7 +67,7 @@ describe PageObject::Elements::OrderedList do
         expect(ol_element).to receive(:map).and_return([ol_element])
         expect(ol_element).to receive(:parent).and_return(ol_element)
         expect(ol_element).to receive(:element).and_return(ol_element)
-        expect(ol_element).to receive(:==).and_return(true)
+        expect(ol_element).to receive(:==).twice.and_return(true)
         ol[1]
       end
 
@@ -77,7 +77,7 @@ describe PageObject::Elements::OrderedList do
         expect(ol_element).to receive(:map).and_return([ol_element])
         expect(ol_element).to receive(:parent).and_return(ol_element)
         expect(ol_element).to receive(:element).and_return(ol_element)
-        expect(ol_element).to receive(:==).and_return(true)
+        expect(ol_element).to receive(:==).twice.and_return(true)
         expect(ol.items).to eql 1
       end
 

--- a/spec/page-object/elements/ordered_list_spec.rb
+++ b/spec/page-object/elements/ordered_list_spec.rb
@@ -30,30 +30,30 @@ describe PageObject::Elements::OrderedList do
     context "for watir" do
       it "should return a list item when indexed" do
         ol = PageObject::Elements::OrderedList.new(ol_element, :platform => :watir_webdriver)
-        ol_element.stub(:ols).and_return([ol_element])
-        ol_element.stub(:find_elements).and_return(ol_element)
-        ol_element.stub(:map).and_return([ol_element])
-        ol_element.stub(:parent).and_return(ol_element)
-        ol_element.stub(:element).and_return(ol_element)
-        ol_element.stub(:==).and_return(true)
+        allow(ol_element).to receive(:ols).and_return([ol_element])
+        allow(ol_element).to receive(:find_elements).and_return(ol_element)
+        allow(ol_element).to receive(:map).and_return([ol_element])
+        allow(ol_element).to receive(:parent).and_return(ol_element)
+        allow(ol_element).to receive(:element).and_return(ol_element)
+        allow(ol_element).to receive(:==).and_return(true)
         ol[1]
       end
 
       it "should know how many list items it contains" do
         ol = PageObject::Elements::OrderedList.new(ol_element, :platform => :watir_webdriver)
-        ol_element.stub(:ols).and_return([ol_element])
-        ol_element.stub(:find_elements).and_return(ol_element)
-        ol_element.stub(:map).and_return([ol_element])
-        ol_element.stub(:parent).and_return(ol_element)
-        ol_element.stub(:element).and_return(ol_element)
-        ol_element.stub(:==).and_return(true)
+        allow(ol_element).to receive(:ols).and_return([ol_element])
+        allow(ol_element).to receive(:find_elements).and_return(ol_element)
+        allow(ol_element).to receive(:map).and_return([ol_element])
+        allow(ol_element).to receive(:parent).and_return(ol_element)
+        allow(ol_element).to receive(:element).and_return(ol_element)
+        allow(ol_element).to receive(:==).and_return(true)
         expect(ol.items).to eql 1
       end
 
       it "should iterate over the list items" do
         ol = PageObject::Elements::OrderedList.new(ol_element, :platform => :watir_webdriver)
-        ol.should_receive(:items).and_return(5)
-        ol.stub(:[])
+        expect(ol).to receive(:items).and_return(5)
+        allow(ol).to receive(:[])
         count = 0
         ol.each { |item| count += 1 }
         expect(count).to eql 5
@@ -63,28 +63,28 @@ describe PageObject::Elements::OrderedList do
     context "for selenium" do
       it "should return a list item when indexed" do
         ol = PageObject::Elements::OrderedList.new(ol_element, :platform => :selenium_webdriver)
-        ol_element.should_receive(:find_elements).and_return(ol_element)
-        ol_element.should_receive(:map).and_return([ol_element])
-        ol_element.should_receive(:parent).and_return(ol_element)
-        ol_element.should_receive(:element).and_return(ol_element)
-        ol_element.should_receive(:==).and_return(true)
+        expect(ol_element).to receive(:find_elements).and_return(ol_element)
+        expect(ol_element).to receive(:map).and_return([ol_element])
+        expect(ol_element).to receive(:parent).and_return(ol_element)
+        expect(ol_element).to receive(:element).and_return(ol_element)
+        expect(ol_element).to receive(:==).and_return(true)
         ol[1]
       end
 
       it "should know how many list items it contains" do
         ol = PageObject::Elements::OrderedList.new(ol_element, :platform => :selenium_webdriver)
-        ol_element.should_receive(:find_elements).and_return(ol_element)
-        ol_element.should_receive(:map).and_return([ol_element])
-        ol_element.should_receive(:parent).and_return(ol_element)
-        ol_element.should_receive(:element).and_return(ol_element)
-        ol_element.should_receive(:==).and_return(true)
+        expect(ol_element).to receive(:find_elements).and_return(ol_element)
+        expect(ol_element).to receive(:map).and_return([ol_element])
+        expect(ol_element).to receive(:parent).and_return(ol_element)
+        expect(ol_element).to receive(:element).and_return(ol_element)
+        expect(ol_element).to receive(:==).and_return(true)
         expect(ol.items).to eql 1
       end
 
       it "should iterate over the list items" do
         ol = PageObject::Elements::OrderedList.new(ol_element, :platform => :selenium_webdriver)
-        ol.should_receive(:items).and_return(5)
-        ol.stub(:[])
+        expect(ol).to receive(:items).and_return(5)
+        allow(ol).to receive(:[])
         count = 0
         ol.each { |item| count += 1 }
         expect(count).to eql 5

--- a/spec/page-object/elements/select_list_spec.rb
+++ b/spec/page-object/elements/select_list_spec.rb
@@ -25,14 +25,14 @@ describe PageObject::Elements::SelectList do
     let(:opts) { [sel_list, sel_list] }
 
     before(:each) do
-      sel_list.stub(:find_elements).and_return(sel_list)
-      sel_list.stub(:each)
-      sel_list.stub(:wd).and_return(sel_list)
-      sel_list.stub(:map).and_return(opts)
-      sel_list.stub(:any?)
-      sel_list.stub(:include?)
-      sel_list.stub(:select).and_return(opts)
-      sel_list.stub(:text).and_return('blah')
+      allow(sel_list).to receive(:find_elements).and_return(sel_list)
+      allow(sel_list).to receive(:each)
+      allow(sel_list).to receive(:wd).and_return(sel_list)
+      allow(sel_list).to receive(:map).and_return(opts)
+      allow(sel_list).to receive(:any?)
+      allow(sel_list).to receive(:include?)
+      allow(sel_list).to receive(:select).and_return(opts)
+      allow(sel_list).to receive(:text).and_return('blah')
     end
 
     it "should register with tag_name :select" do
@@ -43,34 +43,34 @@ describe PageObject::Elements::SelectList do
       let(:watir_sel_list) { PageObject::Elements::SelectList.new(sel_list, :platform => :watir_webdriver) }
 
       it "should return an option when indexed" do
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
         expect(watir_sel_list[0]).to be_instance_of PageObject::Elements::Option
       end
 
       it "should return an array of options" do
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
         expect(watir_sel_list.options.size).to eql 2
       end
 
       it "should return an array of selected options" do
-        sel_list.stub(:selected_options).and_return(opts)
-        sel_list.stub(:text).and_return(sel_list)
+        allow(sel_list).to receive(:selected_options).and_return(opts)
+        allow(sel_list).to receive(:text).and_return(sel_list)
         expect(watir_sel_list.selected_options).to eql opts
       end
 
       it "should know if it includes some value" do
-        sel_list.stub(:include?).with('blah').and_return(true)
+        allow(sel_list).to receive(:include?).with('blah').and_return(true)
         watir_sel_list.include?('blah')
       end
 
       it "should know if an option is selected" do
-        sel_list.stub(:selected?).with('blah').and_return(true)
+        allow(sel_list).to receive(:selected?).with('blah').and_return(true)
         watir_sel_list.selected?('blah')
       end
 
       it "should be able to get the value for the selected options" do
-        sel_list.stub(:selected_options).and_return(opts)
-        sel_list.stub(:value).and_return(sel_list)
+        allow(sel_list).to receive(:selected_options).and_return(opts)
+        allow(sel_list).to receive(:value).and_return(sel_list)
         expect(watir_sel_list.selected_values).to eql opts
       end
     end
@@ -79,61 +79,61 @@ describe PageObject::Elements::SelectList do
       let(:selenium_sel_list) { PageObject::Elements::SelectList.new(sel_list, :platform => :selenium_webdriver) }
 
       it "should return an option when indexed" do
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
         expect(selenium_sel_list[1]).to be_instance_of PageObject::Elements::Option
       end
 
       it "should return an array of options" do
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
         expect(selenium_sel_list.options.size).to eql 2
       end
 
       it "should select an element" do
         option = double('option')
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return([option])
-        option.should_receive(:text).and_return('something')
-        option.should_receive(:click)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return([option])
+        expect(option).to receive(:text).and_return('something')
+        expect(option).to receive(:click)
         selenium_sel_list.select 'something'
       end
 
       it "should return an array of selected options" do
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
-        opts[0].should_receive(:selected?).and_return(true)
-        opts[0].should_receive(:text).and_return('test1')
-        opts[1].should_receive(:selected?).and_return(false)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(opts[0]).to receive(:selected?).and_return(true)
+        expect(opts[0]).to receive(:text).and_return('test1')
+        expect(opts[1]).to receive(:selected?).and_return(false)
         selected = selenium_sel_list.selected_options
         expect(selected.size).to eql 1
         expect(selected[0]).to eql 'test1'
       end
 
       it "should return an array of selected options" do
-        sel_list.should_receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
-        opts[0].should_receive(:selected?).and_return(true)
-        opts[0].should_receive(:attribute).and_return('test1')
-        opts[1].should_receive(:selected?).and_return(false)
+        expect(sel_list).to receive(:find_elements).with(:xpath, ".//child::option").and_return(opts)
+        expect(opts[0]).to receive(:selected?).and_return(true)
+        expect(opts[0]).to receive(:attribute).and_return('test1')
+        expect(opts[1]).to receive(:selected?).and_return(false)
         selected = selenium_sel_list.selected_values
         expect(selected.size).to eql 1
         expect(selected[0]).to eql 'test1'
       end
 
       it "should know if it includes some value" do
-        sel_list.should_receive(:find_elements).and_return(opts)
-        opts[0].should_receive(:text).and_return('blah')
+        expect(sel_list).to receive(:find_elements).and_return(opts)
+        expect(opts[0]).to receive(:text).and_return('blah')
         expect(selenium_sel_list).to include 'blah'
       end
 
       it "should know if an option is selected" do
-        sel_list.should_receive(:find_elements).and_return(opts)
-        opts[0].should_receive(:selected?).twice.and_return(true)
-        opts[0].should_receive(:text).and_return('blah')
+        expect(sel_list).to receive(:find_elements).and_return(opts)
+        expect(opts[0]).to receive(:selected?).twice.and_return(true)
+        expect(opts[0]).to receive(:text).and_return('blah')
         expect(selenium_sel_list.selected?('blah')).to be true
       end
 
       it "should be able to clear selected options" do
-        sel_list.should_receive(:find_elements).and_return(opts)
+        expect(sel_list).to receive(:find_elements).and_return(opts)
         opts.each do |opt|
-          opt.should_receive(:selected?).and_return(true)
-          opt.should_receive(:click)
+          expect(opt).to receive(:selected?).and_return(true)
+          expect(opt).to receive(:click)
         end
         selenium_sel_list.clear
       end

--- a/spec/page-object/elements/selenium/radio_button_spec.rb
+++ b/spec/page-object/elements/selenium/radio_button_spec.rb
@@ -30,13 +30,13 @@ describe PageObject::Elements::RadioButton do
       let(:radio_button) { PageObject::Elements::RadioButton.new(selenium_rb, :platform => :selenium_webdriver) }
 
       it "should select" do
-        selenium_rb.should_receive(:click)
-        selenium_rb.should_receive(:selected?).and_return(false)
+        expect(selenium_rb).to receive(:click)
+        expect(selenium_rb).to receive(:selected?).and_return(false)
         radio_button.select
       end
       
       it "should know if it is selected" do
-        selenium_rb.should_receive(:selected?).and_return(true)
+        expect(selenium_rb).to receive(:selected?).and_return(true)
         expect(radio_button).to be_selected
       end
     end

--- a/spec/page-object/elements/selenium/text_field_spec.rb
+++ b/spec/page-object/elements/selenium/text_field_spec.rb
@@ -34,14 +34,14 @@ describe PageObject::Elements::TextField do
     end
 
     it "should append text" do
-      text_field_element.should_receive(:send_keys).with('abc')
+      expect(text_field_element).to receive(:send_keys).with('abc')
       selenium_text_field.append('abc')
     end
     
     context "for selenium" do
       it "should set its' value" do
-        text_field_element.should_receive(:clear)
-        text_field_element.should_receive(:send_keys).with('Joseph')
+        expect(text_field_element).to receive(:clear)
+        expect(text_field_element).to receive(:send_keys).with('Joseph')
         selenium_text_field.value = 'Joseph'
       end
     end

--- a/spec/page-object/elements/selenium_element_spec.rb
+++ b/spec/page-object/elements/selenium_element_spec.rb
@@ -76,7 +76,7 @@ describe "Element for Selenium" do
     expect(@selenium_driver).to receive(:double_click)
     @selenium_element.double_click
   end
-  
+
   it "should be right clickable" do
     expect(@selenium_driver).to receive(:context_click)
     @selenium_element.right_click
@@ -88,7 +88,7 @@ describe "Element for Selenium" do
     expect(wait).to receive(:until)
     @selenium_element.when_present(10)
   end
-  
+
   it "should return the element when it is present" do
     wait = double('wait')
     expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
@@ -110,7 +110,7 @@ describe "Element for Selenium" do
     expect(wait).to receive(:until)
     @selenium_element.when_visible(10)
   end
-  
+
   it "should return the element when it is visible" do
     wait = double('wait')
     expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
@@ -145,7 +145,7 @@ describe "Element for Selenium" do
     expect(@selenium_driver).to receive(:send_keys).with([:control, 'a'])
     @selenium_element.send_keys([:control, 'a'])
   end
-  
+
   it "should clear its' contents" do
     expect(@selenium_driver).to receive(:clear)
     @selenium_element.clear
@@ -173,5 +173,46 @@ describe "Element for Selenium" do
   it "should scroll into view" do
     expect(@selenium_driver).to receive(:location_once_scrolled_into_view)
     @selenium_element.scroll_into_view
+  end
+
+  it "should have a y location" do
+    expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
+    expect(@selenium_element.location_y).to eql 80
+  end
+
+  it "should have an x location" do
+    expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
+    expect(@selenium_element.location_x).to eql 40
+  end
+
+  it "should have a height" do
+    expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(@selenium_element.height).to eql 20
+  end
+
+  it "should have a width" do
+    expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(@selenium_element.width).to eql 30
+  end
+
+  it "should have a centre" do
+    expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
+    expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(@selenium_element.centre).to include(
+      'y' => 90,
+      'x' => 55
+    )
+  end
+
+  it "should have a centre greater than y position" do
+    expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
+    expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(@selenium_element.centre['y']).to be > @selenium_element.location_y
+  end
+
+  it "should have a centre greater than x position" do
+    expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
+    expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(@selenium_element.centre['x']).to be > @selenium_element.location_x
   end
 end

--- a/spec/page-object/elements/selenium_element_spec.rb
+++ b/spec/page-object/elements/selenium_element_spec.rb
@@ -177,12 +177,12 @@ describe "Element for Selenium" do
 
   it "should have a y location" do
     expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
-    expect(@selenium_element.location_y).to eql 80
+    expect(@selenium_element.location['y']).to eql 80
   end
 
   it "should have an x location" do
     expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
-    expect(@selenium_element.location_x).to eql 40
+    expect(@selenium_element.location['x']).to eql 40
   end
 
   it "should have a height" do
@@ -207,12 +207,12 @@ describe "Element for Selenium" do
   it "should have a centre greater than y position" do
     expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
     expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
-    expect(@selenium_element.centre['y']).to be > @selenium_element.location_y
+    expect(@selenium_element.centre['y']).to be > @selenium_element.location['y']
   end
 
   it "should have a centre greater than x position" do
     expect(@selenium_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
     expect(@selenium_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
-    expect(@selenium_element.centre['x']).to be > @selenium_element.location_x
+    expect(@selenium_element.centre['x']).to be > @selenium_element.location['x']
   end
 end

--- a/spec/page-object/elements/selenium_element_spec.rb
+++ b/spec/page-object/elements/selenium_element_spec.rb
@@ -9,17 +9,17 @@ describe "Element for Selenium" do
   end
 
   it "should know when it is visible" do
-    @selenium_driver.should_receive(:displayed?).and_return(true)
+    expect(@selenium_driver).to receive(:displayed?).and_return(true)
     expect(@selenium_element.visible?).to be true
   end
 
   it "should know when it is not visible" do
-    @selenium_driver.should_receive(:displayed?).and_return(false)
+    expect(@selenium_driver).to receive(:displayed?).and_return(false)
     expect(@selenium_element.visible?).to eql false
   end
 
   it "should know when it exists" do
-    @selenium_driver.should_receive(:nil?).and_return(false)
+    expect(@selenium_driver).to receive(:nil?).and_return(false)
     expect(@selenium_element.exists?).to eql true
   end
 
@@ -30,143 +30,143 @@ describe "Element for Selenium" do
 
   it "should flash an element" do
     bridge = double('bridge')
-    @selenium_driver.should_receive(:attribute).and_return('blue')
-    @selenium_driver.should_receive(:instance_variable_get).and_return(bridge)
-    bridge.should_receive(:executeScript).exactly(10).times
+    expect(@selenium_driver).to receive(:attribute).and_return('blue')
+    expect(@selenium_driver).to receive(:instance_variable_get).and_return(bridge)
+    expect(bridge).to receive(:executeScript).exactly(10).times
     @selenium_element.flash
   end
 
   it "should be able to return the text contained in the element" do
-    @selenium_driver.should_receive(:text).and_return("my text")
+    expect(@selenium_driver).to receive(:text).and_return("my text")
     expect(@selenium_element.text).to eql "my text"
   end
 
   it "should know when it is equal to another" do
-    @selenium_driver.should_receive(:==).and_return(true)
+    expect(@selenium_driver).to receive(:==).and_return(true)
     expect(@selenium_element).to eq @selenium_element
   end
 
   it "should return its tag name" do
-    @selenium_driver.should_receive(:tag_name).and_return("h1")
+    expect(@selenium_driver).to receive(:tag_name).and_return("h1")
     expect(@selenium_element.tag_name).to eql "h1"
   end
 
   it "should know its value" do
-    @selenium_driver.should_receive(:attribute).with('value').and_return("value")
+    expect(@selenium_driver).to receive(:attribute).with('value').and_return("value")
     expect(@selenium_element.value).to eql "value"
   end
 
   it "should know how to retrieve the value of an attribute" do
-    @selenium_driver.should_receive(:attribute).and_return(true)
+    expect(@selenium_driver).to receive(:attribute).and_return(true)
     expect(@selenium_element.attribute('readonly')).to be true
   end
 
   it "should be clickable" do
-    @selenium_driver.should_receive(:click)
+    expect(@selenium_driver).to receive(:click)
     @selenium_element.click
   end
 
   it "should be double clickable" do
-    Selenium::WebDriver::Mouse.should_receive(:new).and_return(@selenium_driver)
-    @selenium_driver.should_receive(:double_click)
+    expect(Selenium::WebDriver::Mouse).to receive(:new).and_return(@selenium_driver)
+    expect(@selenium_driver).to receive(:double_click)
     @selenium_element.double_click
   end
   
   it "should be right clickable" do
-    @selenium_driver.should_receive(:context_click)
+    expect(@selenium_driver).to receive(:context_click)
     @selenium_element.right_click
   end
 
   it "should be able to block until it is present" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     @selenium_element.when_present(10)
   end
   
   it "should return the element when it is present" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     element = @selenium_element.when_present(10)
     expect(element).to equal @selenium_element
   end
 
   it "should return when an element is not present" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     @selenium_element.when_not_present
   end
 
   it "should be able to block until it is visible" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     @selenium_element.when_visible(10)
   end
   
   it "should return the element when it is visible" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     element = @selenium_element.when_visible(10)
     expect(element).to equal @selenium_element
   end
 
   it "should be able to block until it is not visible" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     @selenium_element.when_not_visible(10)
   end
 
   it "should return the element when it is not visible" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     element = @selenium_element.when_not_visible(10)
     expect(element).to equal @selenium_element
   end
 
   it "should be able to block until a user define event fires true" do
     wait = double('wait')
-    ::Selenium::WebDriver::Wait.should_receive(:new).and_return(wait)
-    wait.should_receive(:until)
+    expect(::Selenium::WebDriver::Wait).to receive(:new).and_return(wait)
+    expect(wait).to receive(:until)
     @selenium_element.wait_until(10, "Element blah") {}
   end
 
   it "should send keys to the element" do
-    @selenium_driver.should_receive(:send_keys).with([:control, 'a'])
+    expect(@selenium_driver).to receive(:send_keys).with([:control, 'a'])
     @selenium_element.send_keys([:control, 'a'])
   end
   
   it "should clear its' contents" do
-    @selenium_driver.should_receive(:clear)
+    expect(@selenium_driver).to receive(:clear)
     @selenium_element.clear
   end
 
   it "should fire an event" do
-    @selenium_driver.should_receive(:instance_variable_get).with(:@bridge).and_return(@selenium_driver)
-    @selenium_driver.should_receive(:executeScript)
+    expect(@selenium_driver).to receive(:instance_variable_get).with(:@bridge).and_return(@selenium_driver)
+    expect(@selenium_driver).to receive(:executeScript)
     @selenium_element.fire_event('onfocus')
   end
 
   it "should find the parent element" do
-    @selenium_driver.should_receive(:instance_variable_get).with(:@bridge).and_return(@selenium_driver)
-    @selenium_driver.should_receive(:executeScript).and_return(@selenium_driver)
-    @selenium_driver.should_receive(:tag_name).twice.and_return(:div)
+    expect(@selenium_driver).to receive(:instance_variable_get).with(:@bridge).and_return(@selenium_driver)
+    expect(@selenium_driver).to receive(:executeScript).and_return(@selenium_driver)
+    expect(@selenium_driver).to receive(:tag_name).twice.and_return(:div)
     @selenium_element.parent
   end
 
   it "should set the focus" do
-    @selenium_driver.should_receive(:instance_variable_get).and_return(@selenium_driver)
-    @selenium_driver.should_receive(:executeScript)
+    expect(@selenium_driver).to receive(:instance_variable_get).and_return(@selenium_driver)
+    expect(@selenium_driver).to receive(:executeScript)
     @selenium_element.focus
   end
 
   it "should scroll into view" do
-    @selenium_driver.should_receive(:location_once_scrolled_into_view)
+    expect(@selenium_driver).to receive(:location_once_scrolled_into_view)
     @selenium_element.scroll_into_view
   end
 end

--- a/spec/page-object/elements/selenium_element_spec.rb
+++ b/spec/page-object/elements/selenium_element_spec.rb
@@ -42,7 +42,7 @@ describe "Element for Selenium" do
   end
 
   it "should know when it is equal to another" do
-    expect(@selenium_driver).to receive(:==).and_return(true)
+    expect(@selenium_driver).to receive(:==).twice.and_return(true)
     expect(@selenium_element).to eq @selenium_element
   end
 

--- a/spec/page-object/elements/table_cell_spec.rb
+++ b/spec/page-object/elements/table_cell_spec.rb
@@ -5,17 +5,17 @@ describe PageObject::Elements::TableCell do
 
   context "interface" do
     it "should register with tag_name :td" do
-      ::PageObject::Elements.element_class_for(:td).should == ::PageObject::Elements::TableCell
+      expect(::PageObject::Elements.element_class_for(:td)).to eql ::PageObject::Elements::TableCell
     end
 
     it "should register with tag_name :th" do
-      ::PageObject::Elements.element_class_for(:th).should == ::PageObject::Elements::TableCell
+      expect(::PageObject::Elements.element_class_for(:th)).to eql ::PageObject::Elements::TableCell
     end
 
     it "should always be enabled" do
       table_cell_element = double('table_cell_element')
       table_cell = PageObject::Elements::TableCell.new(table_cell_element, :platform => :selenium_webdriver)
-      table_cell.enabled?.should be true
+      expect(table_cell.enabled?).to be true
     end
   end
 end

--- a/spec/page-object/elements/table_row_spec.rb
+++ b/spec/page-object/elements/table_row_spec.rb
@@ -8,7 +8,7 @@ describe PageObject::Elements::TableRow do
   describe "interface" do
 
     it "should register with tag_name :tr" do
-      ::PageObject::Elements.element_class_for(:tr).should == ::PageObject::Elements::TableRow
+      expect(::PageObject::Elements.element_class_for(:tr)).to eql ::PageObject::Elements::TableRow
     end
     
     context "for selenium" do
@@ -17,14 +17,14 @@ describe PageObject::Elements::TableRow do
         table_row.stub(:columns).and_return(2)
         table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_cell)
         table_cell.should_receive(:[]).and_return(table_cell)
-        table_row[0].should be_instance_of PageObject::Elements::TableCell
+        expect(table_row[0]).to be_instance_of PageObject::Elements::TableCell
       end
 
       it "should retrun the number of columns" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :selenium_webdriver)
         table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_row_driver)
         table_row_driver.should_receive(:size).and_return(3)
-        table_row.columns.should == 3
+        expect(table_row.columns).to eql 3
       end
 
       it "should iterate over the table columns" do
@@ -33,7 +33,7 @@ describe PageObject::Elements::TableRow do
         table_row.stub(:[]).and_return(table_row_driver)
         count = 0
         table_row.each { |e| count += 1 }
-        count.should == 2
+        expect(count).to eql 2
       end
     end
 
@@ -46,7 +46,7 @@ describe PageObject::Elements::TableRow do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :watir_webdriver)
         table_row.stub(:columns).and_return(2)
         table_row_driver.should_receive(:[]).with(1).and_return(table_cell)
-        table_row[1].should be_instance_of PageObject::Elements::TableCell
+        expect(table_row[1]).to be_instance_of PageObject::Elements::TableCell
       end
 
       it "should return the number of columns" do
@@ -54,7 +54,7 @@ describe PageObject::Elements::TableRow do
         table_row_driver.stub(:wd).and_return(table_row_driver)
         table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_row_driver)
         table_row_driver.should_receive(:size).and_return(3)
-        table_row.columns.should == 3
+        expect(table_row.columns).to eql 3
       end
 
       it "should iterate over the table columns" do
@@ -63,7 +63,7 @@ describe PageObject::Elements::TableRow do
         table_row.stub(:[])
         count = 0
         table_row.each { |e| count += 1 }
-        count.should == 2
+        expect(count).to eql 2
       end
     end
   end

--- a/spec/page-object/elements/table_row_spec.rb
+++ b/spec/page-object/elements/table_row_spec.rb
@@ -14,23 +14,23 @@ describe PageObject::Elements::TableRow do
     context "for selenium" do
       it "should return a table cell when indexed" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :selenium_webdriver)
-        table_row.stub(:columns).and_return(2)
-        table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_cell)
-        table_cell.should_receive(:[]).and_return(table_cell)
+        allow(table_row).to receive(:columns).and_return(2)
+        expect(table_row_driver).to receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_cell)
+        expect(table_cell).to receive(:[]).and_return(table_cell)
         expect(table_row[0]).to be_instance_of PageObject::Elements::TableCell
       end
 
       it "should retrun the number of columns" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :selenium_webdriver)
-        table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_row_driver)
-        table_row_driver.should_receive(:size).and_return(3)
+        expect(table_row_driver).to receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_row_driver)
+        expect(table_row_driver).to receive(:size).and_return(3)
         expect(table_row.columns).to eql 3
       end
 
       it "should iterate over the table columns" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :selenium_webdriver)
-        table_row.should_receive(:columns).and_return(2)
-        table_row.stub(:[]).and_return(table_row_driver)
+        expect(table_row).to receive(:columns).and_return(2)
+        allow(table_row).to receive(:[]).and_return(table_row_driver)
         count = 0
         table_row.each { |e| count += 1 }
         expect(count).to eql 2
@@ -39,28 +39,28 @@ describe PageObject::Elements::TableRow do
 
     context "for watir" do
       before(:each) do
-        table_row_driver.stub(:find_elements).and_return(table_row_driver)
+        allow(table_row_driver).to receive(:find_elements).and_return(table_row_driver)
       end
 
       it "should return a table cell when indexed" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :watir_webdriver)
-        table_row.stub(:columns).and_return(2)
-        table_row_driver.should_receive(:[]).with(1).and_return(table_cell)
+        allow(table_row).to receive(:columns).and_return(2)
+        expect(table_row_driver).to receive(:[]).with(1).and_return(table_cell)
         expect(table_row[1]).to be_instance_of PageObject::Elements::TableCell
       end
 
       it "should return the number of columns" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :watir_webdriver)
-        table_row_driver.stub(:wd).and_return(table_row_driver)
-        table_row_driver.should_receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_row_driver)
-        table_row_driver.should_receive(:size).and_return(3)
+        allow(table_row_driver).to receive(:wd).and_return(table_row_driver)
+        expect(table_row_driver).to receive(:find_elements).with(:xpath, ".//child::td|th").and_return(table_row_driver)
+        expect(table_row_driver).to receive(:size).and_return(3)
         expect(table_row.columns).to eql 3
       end
 
       it "should iterate over the table columns" do
         table_row = PageObject::Elements::TableRow.new(table_row_driver, :platform => :watir_webdriver)
-        table_row.should_receive(:columns).and_return(2)
-        table_row.stub(:[])
+        expect(table_row).to receive(:columns).and_return(2)
+        allow(table_row).to receive(:[])
         count = 0
         table_row.each { |e| count += 1 }
         expect(count).to eql 2

--- a/spec/page-object/elements/table_spec.rb
+++ b/spec/page-object/elements/table_spec.rb
@@ -22,8 +22,8 @@ describe PageObject::Elements::Table do
     let(:table_element) { double('table_element') }
 
     before(:each) do
-      table_element.stub(:[]).and_return(table_element)
-      table_element.stub(:find_elements).and_return(table_element)
+      allow(table_element).to receive(:[]).and_return(table_element)
+      allow(table_element).to receive(:find_elements).and_return(table_element)
     end
 
     it "should register with tag_name :table" do
@@ -34,29 +34,29 @@ describe PageObject::Elements::Table do
       let(:watir_table) { PageObject::Elements::Table.new(table_element, :platform => :watir_webdriver) }
       
       it "should return a table row when indexed" do
-        table_element.stub(:[]).with(1).and_return(table_element)
+        allow(table_element).to receive(:[]).with(1).and_return(table_element)
         expect(watir_table[1]).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the first row" do
-        table_element.stub(:[]).with(0).and_return(table_element)
+        allow(table_element).to receive(:[]).with(0).and_return(table_element)
         expect(watir_table.first_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "shoudl return the last row" do
-        table_element.stub(:[]).with(-1).and_return(table_element)
+        allow(table_element).to receive(:[]).with(-1).and_return(table_element)
         expect(watir_table.last_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the number of rows" do
-        table_element.stub(:wd).and_return(table_element)
-        table_element.should_receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
-        table_element.should_receive(:size).and_return(2)
+        allow(table_element).to receive(:wd).and_return(table_element)
+        expect(table_element).to receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
+        expect(table_element).to receive(:size).and_return(2)
         expect(watir_table.rows).to eql 2
       end
 
       it "should iterate over the table rows" do
-        watir_table.should_receive(:rows).and_return(2)
+        expect(watir_table).to receive(:rows).and_return(2)
         count = 0
         watir_table.each { |e| count += 1 }
         expect(count).to eql 2
@@ -67,28 +67,28 @@ describe PageObject::Elements::Table do
       let(:selenium_table) { PageObject::Elements::Table.new(table_element, :platform => :selenium_webdriver) }
       
       it "should return a table row when indexed" do
-        table_element.should_receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
+        expect(table_element).to receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
         expect(selenium_table[1]).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the first row" do
-        table_element.stub(:[]).with(0).and_return(table_element)
+        allow(table_element).to receive(:[]).with(0).and_return(table_element)
         expect(selenium_table.first_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "shoudl return the last row" do
-        table_element.stub(:[]).with(-1).and_return(table_element)
+        allow(table_element).to receive(:[]).with(-1).and_return(table_element)
         expect(selenium_table.last_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the number of rows" do
-        table_element.should_receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
-        table_element.should_receive(:size).and_return(2)
+        expect(table_element).to receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
+        expect(table_element).to receive(:size).and_return(2)
         expect(selenium_table.rows).to eql 2
       end
 
       it "should iterate over the table rows" do
-        selenium_table.should_receive(:rows).and_return(2)
+        allow(selenium_table).to receive(:rows).and_return(2)
         count = 0
         selenium_table.each { |e| count += 1 }
         expect(count).to eql 2

--- a/spec/page-object/elements/table_spec.rb
+++ b/spec/page-object/elements/table_spec.rb
@@ -6,14 +6,14 @@ describe PageObject::Elements::Table do
     it "should map watir types to same" do
       [:class, :id, :index, :xpath].each do |t|
         identifier = PageObject::Elements::Table.watir_identifier_for t => 'value'
-        identifier.keys.first.should == t
+        expect(identifier.keys.first).to eql t
       end
     end
 
     it "should map selenium types to same" do
       [:class, :id, :index, :name, :xpath].each do |t|
         key, value = PageObject::Elements::Table.selenium_identifier_for t => 'value'
-        key.should == t
+        expect(key).to eql t
       end
     end
   end
@@ -27,7 +27,7 @@ describe PageObject::Elements::Table do
     end
 
     it "should register with tag_name :table" do
-      ::PageObject::Elements.element_class_for(:table).should == ::PageObject::Elements::Table
+      expect(::PageObject::Elements.element_class_for(:table)).to eql ::PageObject::Elements::Table
     end
 
     context "for watir" do
@@ -35,31 +35,31 @@ describe PageObject::Elements::Table do
       
       it "should return a table row when indexed" do
         table_element.stub(:[]).with(1).and_return(table_element)
-        watir_table[1].should be_instance_of PageObject::Elements::TableRow
+        expect(watir_table[1]).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the first row" do
         table_element.stub(:[]).with(0).and_return(table_element)
-        watir_table.first_row.should be_instance_of PageObject::Elements::TableRow
+        expect(watir_table.first_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "shoudl return the last row" do
         table_element.stub(:[]).with(-1).and_return(table_element)
-        watir_table.last_row.should be_instance_of PageObject::Elements::TableRow
+        expect(watir_table.last_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the number of rows" do
         table_element.stub(:wd).and_return(table_element)
         table_element.should_receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
         table_element.should_receive(:size).and_return(2)
-        watir_table.rows.should == 2
+        expect(watir_table.rows).to eql 2
       end
 
       it "should iterate over the table rows" do
         watir_table.should_receive(:rows).and_return(2)
         count = 0
         watir_table.each { |e| count += 1 }
-        count.should == 2
+        expect(count).to eql 2
       end
     end
 
@@ -68,30 +68,30 @@ describe PageObject::Elements::Table do
       
       it "should return a table row when indexed" do
         table_element.should_receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
-        selenium_table[1].should be_instance_of PageObject::Elements::TableRow
+        expect(selenium_table[1]).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the first row" do
         table_element.stub(:[]).with(0).and_return(table_element)
-        selenium_table.first_row.should be_instance_of PageObject::Elements::TableRow
+        expect(selenium_table.first_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "shoudl return the last row" do
         table_element.stub(:[]).with(-1).and_return(table_element)
-        selenium_table.last_row.should be_instance_of PageObject::Elements::TableRow
+        expect(selenium_table.last_row).to be_instance_of PageObject::Elements::TableRow
       end
 
       it "should return the number of rows" do
         table_element.should_receive(:find_elements).with(:xpath, ".//child::tr").and_return(table_element)
         table_element.should_receive(:size).and_return(2)
-        selenium_table.rows.should == 2
+        expect(selenium_table.rows).to eql 2
       end
 
       it "should iterate over the table rows" do
         selenium_table.should_receive(:rows).and_return(2)
         count = 0
         selenium_table.each { |e| count += 1 }
-        count.should == 2
+        expect(count).to eql 2
       end
     end
   end

--- a/spec/page-object/elements/text_area_spec.rb
+++ b/spec/page-object/elements/text_area_spec.rb
@@ -30,8 +30,8 @@ describe PageObject::Elements::TextArea do
       it "should set its' value" do
         text_area_element = double('text_area')
         text_area = PageObject::Elements::TextArea.new(text_area_element, :platform => :selenium_webdriver)
-        text_area_element.should_receive(:clear)
-        text_area_element.should_receive(:send_keys).with('Joseph')
+        expect(text_area_element).to receive(:clear)
+        expect(text_area_element).to receive(:send_keys).with('Joseph')
         text_area.value = 'Joseph'
       end
     end

--- a/spec/page-object/elements/text_area_spec.rb
+++ b/spec/page-object/elements/text_area_spec.rb
@@ -8,14 +8,14 @@ describe PageObject::Elements::TextArea do
     it "should map watir types to same" do
       [:class, :id, :index, :name, :xpath].each do |t|
         identifier = textarea.watir_identifier_for t => 'value'
-        identifier.keys.first.should == t
+        expect(identifier.keys.first).to eql t
       end
     end
 
     it "should map selenium types to same" do
       [:class, :id, :name, :xpath, :index].each do |t|
         key, value = textarea.selenium_identifier_for t => 'value'
-        key.should == t
+        expect(key).to eql t
       end
     end
   end
@@ -23,7 +23,7 @@ describe PageObject::Elements::TextArea do
   describe "interface" do
 
     it "should register with tag_name :textarea" do
-      ::PageObject::Elements.element_class_for(:textarea).should == ::PageObject::Elements::TextArea
+      expect(::PageObject::Elements.element_class_for(:textarea)).to eql ::PageObject::Elements::TextArea
     end
     
     context "for Selenium" do

--- a/spec/page-object/elements/unordered_list_spec.rb
+++ b/spec/page-object/elements/unordered_list_spec.rb
@@ -30,30 +30,30 @@ describe PageObject::Elements::UnorderedList do
     context "for watir" do
       it "should return a list item when indexed" do
         ul = PageObject::Elements::UnorderedList.new(ul_element, :platform => :watir_webdriver)
-        ul_element.stub(:uls).and_return([ul_element])
-        ul_element.stub(:find_elements).and_return(ul_element)
-        ul_element.stub(:map).and_return([ul_element])
-        ul_element.stub(:parent).and_return(ul_element)
-        ul_element.stub(:element).and_return(ul_element)
-        ul_element.stub(:==).and_return(true)
+        allow(ul_element).to receive(:uls).and_return([ul_element])
+        allow(ul_element).to receive(:find_elements).and_return(ul_element)
+        allow(ul_element).to receive(:map).and_return([ul_element])
+        allow(ul_element).to receive(:parent).and_return(ul_element)
+        allow(ul_element).to receive(:element).and_return(ul_element)
+        allow(ul_element).to receive(:==).and_return(true)
         ul[1]
       end
 
       it "should know how many items it contains" do
         ul = PageObject::Elements::UnorderedList.new(ul_element, :platform => :watir_webdriver)
-        ul_element.stub(:uls).and_return([ul_element])
-        ul_element.stub(:find_elements).and_return(ul_element)
-        ul_element.stub(:map).and_return([ul_element])
-        ul_element.stub(:parent).and_return(ul_element)
-        ul_element.stub(:element).and_return(ul_element)
-        ul_element.stub(:==).and_return(true)
+        allow(ul_element).to receive(:uls).and_return([ul_element])
+        allow(ul_element).to receive(:find_elements).and_return(ul_element)
+        allow(ul_element).to receive(:map).and_return([ul_element])
+        allow(ul_element).to receive(:parent).and_return(ul_element)
+        allow(ul_element).to receive(:element).and_return(ul_element)
+        allow(ul_element).to receive(:==).and_return(true)
         expect(ul.items).to eql 1
       end
 
       it "should know how to iterate over the items" do
         ul = PageObject::Elements::UnorderedList.new(ul_element, :platform => :watir_webdriver)
-        ul.should_receive(:items).and_return(5)
-        ul.stub(:[])
+        expect(ul).to receive(:items).and_return(5)
+        allow(ul).to receive(:[])
         count = 0
         ul.each { |item| count += 1 }
         expect(count).to eql 5
@@ -63,28 +63,28 @@ describe PageObject::Elements::UnorderedList do
     context "for selenium" do
       it "should return a list item when indexed" do
         ul = PageObject::Elements::UnorderedList.new(ul_element, :platform => :selenium_webdriver)
-        ul_element.should_receive(:find_elements).and_return(ul_element)
-        ul_element.should_receive(:map).and_return([ul_element])
-        ul_element.should_receive(:parent).and_return(ul_element)
-        ul_element.should_receive(:element).and_return(ul_element)
-        ul_element.should_receive(:==).and_return(true)
+        expect(ul_element).to receive(:find_elements).and_return(ul_element)
+        expect(ul_element).to receive(:map).and_return([ul_element])
+        expect(ul_element).to receive(:parent).and_return(ul_element)
+        expect(ul_element).to receive(:element).and_return(ul_element)
+        expect(ul_element).to receive(:==).and_return(true)
         ul[1]
       end
 
       it "should know how many items it contains" do
         ul = PageObject::Elements::UnorderedList.new(ul_element, :platform => :selenium_webdriver)
-        ul_element.should_receive(:find_elements).and_return(ul_element)
-        ul_element.should_receive(:map).and_return([ul_element])
-        ul_element.should_receive(:parent).and_return(ul_element)
-        ul_element.should_receive(:element).and_return(ul_element)
-        ul_element.should_receive(:==).and_return(true)
+        expect(ul_element).to receive(:find_elements).and_return(ul_element)
+        expect(ul_element).to receive(:map).and_return([ul_element])
+        expect(ul_element).to receive(:parent).and_return(ul_element)
+        expect(ul_element).to receive(:element).and_return(ul_element)
+        expect(ul_element).to receive(:==).and_return(true)
         expect(ul.items).to eql 1
       end
 
       it "should know how to iterate over the items" do
         ul = PageObject::Elements::UnorderedList.new(ul_element, :platform => :selenium_webdriver)
-        ul.should_receive(:items).and_return(5)
-        ul.stub(:[])
+        expect(ul).to receive(:items).and_return(5)
+        allow(ul).to receive(:[])
         count = 0
         ul.each { |item| count += 1 }
         expect(count).to eql 5

--- a/spec/page-object/elements/unordered_list_spec.rb
+++ b/spec/page-object/elements/unordered_list_spec.rb
@@ -67,7 +67,7 @@ describe PageObject::Elements::UnorderedList do
         expect(ul_element).to receive(:map).and_return([ul_element])
         expect(ul_element).to receive(:parent).and_return(ul_element)
         expect(ul_element).to receive(:element).and_return(ul_element)
-        expect(ul_element).to receive(:==).and_return(true)
+        expect(ul_element).to receive(:==).twice.and_return(true)
         ul[1]
       end
 
@@ -77,7 +77,7 @@ describe PageObject::Elements::UnorderedList do
         expect(ul_element).to receive(:map).and_return([ul_element])
         expect(ul_element).to receive(:parent).and_return(ul_element)
         expect(ul_element).to receive(:element).and_return(ul_element)
-        expect(ul_element).to receive(:==).and_return(true)
+        expect(ul_element).to receive(:==).twice.and_return(true)
         expect(ul.items).to eql 1
       end
 

--- a/spec/page-object/elements/unordered_list_spec.rb
+++ b/spec/page-object/elements/unordered_list_spec.rb
@@ -8,14 +8,14 @@ describe PageObject::Elements::UnorderedList do
     it "should map watir types to same" do
       [:class, :id, :index, :xpath].each do |t|
         identifier = ul.watir_identifier_for t => 'value'
-        identifier.keys.first.should == t
+        expect(identifier.keys.first).to eql t
       end
     end
 
     it "should map selenium types to same" do
       [:class, :id, :index, :name, :xpath].each do |t|
         key, value = ul.selenium_identifier_for t => 'value'
-        key.should == t
+        expect(key).to eql t
       end
     end
   end
@@ -24,7 +24,7 @@ describe PageObject::Elements::UnorderedList do
     let(:ul_element) { double('ul_element') }
 
     it "should register with tag_name :ul" do
-      ::PageObject::Elements.element_class_for(:ul).should == ::PageObject::Elements::UnorderedList
+      expect(::PageObject::Elements.element_class_for(:ul)).to eql ::PageObject::Elements::UnorderedList
     end
 
     context "for watir" do
@@ -47,7 +47,7 @@ describe PageObject::Elements::UnorderedList do
         ul_element.stub(:parent).and_return(ul_element)
         ul_element.stub(:element).and_return(ul_element)
         ul_element.stub(:==).and_return(true)
-        ul.items.should == 1
+        expect(ul.items).to eql 1
       end
 
       it "should know how to iterate over the items" do
@@ -56,7 +56,7 @@ describe PageObject::Elements::UnorderedList do
         ul.stub(:[])
         count = 0
         ul.each { |item| count += 1 }
-        count.should == 5
+        expect(count).to eql 5
       end
     end
 
@@ -78,7 +78,7 @@ describe PageObject::Elements::UnorderedList do
         ul_element.should_receive(:parent).and_return(ul_element)
         ul_element.should_receive(:element).and_return(ul_element)
         ul_element.should_receive(:==).and_return(true)
-        ul.items.should == 1
+        expect(ul.items).to eql 1
       end
 
       it "should know how to iterate over the items" do
@@ -87,8 +87,7 @@ describe PageObject::Elements::UnorderedList do
         ul.stub(:[])
         count = 0
         ul.each { |item| count += 1 }
-        count.should == 5
-
+        expect(count).to eql 5
       end
     end
   end

--- a/spec/page-object/elements/watir_element_spec.rb
+++ b/spec/page-object/elements/watir_element_spec.rb
@@ -6,136 +6,136 @@ describe "Element for Watir" do
   let(:watir_element) { ::PageObject::Elements::Element.new(watir_driver, :platform => :watir_webdriver) }
 
   before(:each) do
-    Selenium::WebDriver::Mouse.stub(:new).and_return(watir_driver)
+    allow(Selenium::WebDriver::Mouse).to receive(:new).and_return(watir_driver)
   end
 
   it "should know when it is visible" do
-    watir_driver.stub(:present?).and_return(true)
-    watir_driver.stub(:displayed?).and_return(true)
+    allow(watir_driver).to receive(:present?).and_return(true)
+    allow(watir_driver).to receive(:displayed?).and_return(true)
     expect(watir_element.visible?).to eql true
   end
 
   it "should know when it is not visible" do
-    watir_driver.stub(:present?).and_return(false)
-    watir_driver.stub(:displayed?).and_return(false)
+    allow(watir_driver).to receive(:present?).and_return(false)
+    allow(watir_driver).to receive(:displayed?).and_return(false)
     expect(watir_element.visible?).to eql false
   end
 
   it "should know when it exists" do
-    watir_driver.stub(:exists?).and_return(true)
+    allow(watir_driver).to receive(:exists?).and_return(true)
     expect(watir_element.exists?).to eql true
   end
 
   it "should know when it does not exist" do
-    watir_driver.stub(:exists?).and_return(false)
-    watir_driver.stub(:nil?).and_return(true)
+    allow(watir_driver).to receive(:exists?).and_return(false)
+    allow(watir_driver).to receive(:nil?).and_return(true)
     expect(watir_element.exists?).to eql false
   end
 
   it "should be able to return the text contained in the element" do
-    watir_driver.should_receive(:text).and_return("my text")
+    expect(watir_driver).to receive(:text).and_return("my text")
     expect(watir_element.text).to eql "my text"
   end
 
   it "should know when it is equal to another" do
-    watir_driver.should_receive(:==).and_return(true)
+    expect(watir_driver).to receive(:==).and_return(true)
     expect(watir_element).to eq watir_element
   end
 
   it "should return its tag name" do
-    watir_driver.should_receive(:tag_name).and_return("h1")
+    expect(watir_driver).to receive(:tag_name).and_return("h1")
     expect(watir_element.tag_name).to eql "h1"
   end
 
   it "should know its value" do
-    watir_driver.stub(:value).and_return("value")
-    watir_driver.stub(:attribute).and_return("value")
+    allow(watir_driver).to receive(:value).and_return("value")
+    allow(watir_driver).to receive(:attribute).and_return("value")
     expect(watir_element.value).to eql "value"
   end
 
   it "should know how to retrieve the value of an attribute" do
-    watir_driver.stub(:attribute_value).and_return(true)
-    watir_driver.stub(:attribute).and_return(true)
+    allow(watir_driver).to receive(:attribute_value).and_return(true)
+    allow(watir_driver).to receive(:attribute).and_return(true)
     expect(watir_element.attribute("readonly")).to be true
   end
 
   it "should be clickable" do
-    watir_driver.should_receive(:click)
+    expect(watir_driver).to receive(:click)
     watir_element.click
   end
   
   it "should be double clickable" do
-    watir_driver.should_receive(:double_click)
+    expect(watir_driver).to receive(:double_click)
     watir_element.double_click
   end
   
   it "should be right clickable" do
-    watir_driver.stub(:right_click)
-    watir_driver.stub(:context_click)
+    allow(watir_driver).to receive(:right_click)
+    allow(watir_driver).to receive(:context_click)
     watir_element.right_click
   end
 
   it "should be able to block until it is present" do
-    watir_driver.stub(:wait_until_present).with(10)
+    allow(watir_driver).to receive(:wait_until_present).with(10)
     watir_element.when_present(10)
   end
   
   it "should return the element when it is present" do
-    watir_driver.stub(:wait_until_present).with(10)
+    allow(watir_driver).to receive(:wait_until_present).with(10)
     element = watir_element.when_present(10)
     expect(element).to equal watir_element
   end
 
   it "should use the overriden wait when set" do
     PageObject.default_element_wait = 20
-    watir_driver.stub(:wait_until_present).with(20)
+    allow(watir_driver).to receive(:wait_until_present).with(20)
     watir_element.when_present
   end
 
   it "should be able to block until it is visible" do
-    ::Watir::Wait.stub(:until).with(10, "Element was not visible in 10 seconds")
-    watir_driver.stub(:displayed?).and_return(true)
+    allow(::Watir::Wait).to receive(:until).with(10, "Element was not visible in 10 seconds")
+    allow(watir_driver).to receive(:displayed?).and_return(true)
     watir_element.when_visible(10)
   end
   
   it "should return the element when it is visible" do
-    ::Watir::Wait.stub(:until).with(10, "Element was not visible in 10 seconds")
-    watir_driver.stub(:displayed?).and_return(true)
+    allow(::Watir::Wait).to receive(:until).with(10, "Element was not visible in 10 seconds")
+    allow(watir_driver).to receive(:displayed?).and_return(true)
     element = watir_element.when_visible(10)
     expect(element).to equal watir_element
   end
 
   it "should be able to block until it is not visible" do
-    ::Watir::Wait.stub(:while).with(10, "Element still visible after 10 seconds")
-    watir_driver.stub(:displayed?).and_return(false)
+    allow(::Watir::Wait).to receive(:while).with(10, "Element still visible after 10 seconds")
+    allow(watir_driver).to receive(:displayed?).and_return(false)
     watir_element.when_not_visible(10)
   end
   
   it "should return the element when it is not visible" do
-    ::Watir::Wait.stub(:while).with(10, "Element still visible after 10 seconds")
-    watir_driver.stub(:displayed?).and_return(false)
+    allow(::Watir::Wait).to receive(:while).with(10, "Element still visible after 10 seconds")
+    allow(watir_driver).to receive(:displayed?).and_return(false)
     element = watir_element.when_not_visible(10)
     expect(element).to equal watir_element
   end
 
   it "should be able to block until a user define event fires true" do
-    ::Watir::Wait.stub(:until).with(10, "Element blah")
+    allow(::Watir::Wait).to receive(:until).with(10, "Element blah")
     watir_element.wait_until(10, "Element blah") {true}
   end
   
   it "should send keys to the element" do
-    watir_driver.should_receive(:send_keys).with([:control, 'a'])
+    expect(watir_driver).to receive(:send_keys).with([:control, 'a'])
     watir_element.send_keys([:control, 'a'])
   end
   
   it "should clear its' contents" do
-    watir_driver.should_receive(:clear)
+    expect(watir_driver).to receive(:clear)
     watir_element.clear
   end
 
   it "should scroll into view" do
-    watir_driver.stub(:wd).and_return(watir_driver)
-    watir_driver.should_receive(:location_once_scrolled_into_view)
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:location_once_scrolled_into_view)
     watir_element.scroll_into_view
   end
 end

--- a/spec/page-object/elements/watir_element_spec.rb
+++ b/spec/page-object/elements/watir_element_spec.rb
@@ -142,4 +142,52 @@ describe "Element for Watir" do
     expect(watir_driver).to receive(:location_once_scrolled_into_view)
     watir_element.scroll_into_view
   end
+
+  it "should have a y location" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
+    expect(watir_element.location_y).to eql 80
+  end
+
+  it "should have a x location" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
+    expect(watir_element.location_x).to eql 40
+  end
+
+  it "should have a height" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(watir_element.height).to eql 20
+  end
+
+  it "should have a width" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(watir_element.width).to eql 30
+  end
+
+  it "should have a centre" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
+    expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(watir_element.centre).to include(
+      'y' => 90,
+      'x' => 55
+    )
+  end
+
+  it "should have a centre greater than y position" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
+    expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(watir_element.centre['y']).to be > watir_element.location_y
+  end
+
+  it "should have a centre greater than x position" do
+    allow(watir_driver).to receive(:wd).and_return(watir_driver)
+    expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
+    expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
+    expect(watir_element.centre['x']).to be > watir_element.location_x
+  end
 end

--- a/spec/page-object/elements/watir_element_spec.rb
+++ b/spec/page-object/elements/watir_element_spec.rb
@@ -38,7 +38,7 @@ describe "Element for Watir" do
   end
 
   it "should know when it is equal to another" do
-    expect(watir_driver).to receive(:==).and_return(true)
+    expect(watir_driver).to receive(:==).twice.and_return(true)
     expect(watir_element).to eq watir_element
   end
 

--- a/spec/page-object/elements/watir_element_spec.rb
+++ b/spec/page-object/elements/watir_element_spec.rb
@@ -12,51 +12,51 @@ describe "Element for Watir" do
   it "should know when it is visible" do
     watir_driver.stub(:present?).and_return(true)
     watir_driver.stub(:displayed?).and_return(true)
-    watir_element.visible?.should == true
+    expect(watir_element.visible?).to eql true
   end
 
   it "should know when it is not visible" do
     watir_driver.stub(:present?).and_return(false)
     watir_driver.stub(:displayed?).and_return(false)
-    watir_element.visible?.should == false
+    expect(watir_element.visible?).to eql false
   end
 
   it "should know when it exists" do
     watir_driver.stub(:exists?).and_return(true)
-    watir_element.exists?.should == true
+    expect(watir_element.exists?).to eql true
   end
 
   it "should know when it does not exist" do
     watir_driver.stub(:exists?).and_return(false)
     watir_driver.stub(:nil?).and_return(true)
-    watir_element.exists?.should == false
+    expect(watir_element.exists?).to eql false
   end
 
   it "should be able to return the text contained in the element" do
     watir_driver.should_receive(:text).and_return("my text")
-    watir_element.text.should == "my text"
+    expect(watir_element.text).to eql "my text"
   end
 
   it "should know when it is equal to another" do
     watir_driver.should_receive(:==).and_return(true)
-    watir_element.should == watir_element
+    expect(watir_element).to eq watir_element
   end
 
   it "should return its tag name" do
     watir_driver.should_receive(:tag_name).and_return("h1")
-    watir_element.tag_name.should == "h1"
+    expect(watir_element.tag_name).to eql "h1"
   end
 
   it "should know its value" do
     watir_driver.stub(:value).and_return("value")
     watir_driver.stub(:attribute).and_return("value")
-    watir_element.value.should == "value"
+    expect(watir_element.value).to eql "value"
   end
 
   it "should know how to retrieve the value of an attribute" do
     watir_driver.stub(:attribute_value).and_return(true)
     watir_driver.stub(:attribute).and_return(true)
-    watir_element.attribute("readonly").should be true
+    expect(watir_element.attribute("readonly")).to be true
   end
 
   it "should be clickable" do
@@ -65,7 +65,6 @@ describe "Element for Watir" do
   end
   
   it "should be double clickable" do
-    
     watir_driver.should_receive(:double_click)
     watir_element.double_click
   end
@@ -84,7 +83,7 @@ describe "Element for Watir" do
   it "should return the element when it is present" do
     watir_driver.stub(:wait_until_present).with(10)
     element = watir_element.when_present(10)
-    element.should === watir_element
+    expect(element).to equal watir_element
   end
 
   it "should use the overriden wait when set" do
@@ -103,7 +102,7 @@ describe "Element for Watir" do
     ::Watir::Wait.stub(:until).with(10, "Element was not visible in 10 seconds")
     watir_driver.stub(:displayed?).and_return(true)
     element = watir_element.when_visible(10)
-    element.should === watir_element
+    expect(element).to equal watir_element
   end
 
   it "should be able to block until it is not visible" do
@@ -116,7 +115,7 @@ describe "Element for Watir" do
     ::Watir::Wait.stub(:while).with(10, "Element still visible after 10 seconds")
     watir_driver.stub(:displayed?).and_return(false)
     element = watir_element.when_not_visible(10)
-    element.should === watir_element
+    expect(element).to equal watir_element
   end
 
   it "should be able to block until a user define event fires true" do

--- a/spec/page-object/elements/watir_element_spec.rb
+++ b/spec/page-object/elements/watir_element_spec.rb
@@ -146,13 +146,13 @@ describe "Element for Watir" do
   it "should have a y location" do
     allow(watir_driver).to receive(:wd).and_return(watir_driver)
     expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
-    expect(watir_element.location_y).to eql 80
+    expect(watir_element.location['y']).to eql 80
   end
 
   it "should have a x location" do
     allow(watir_driver).to receive(:wd).and_return(watir_driver)
     expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40})
-    expect(watir_element.location_x).to eql 40
+    expect(watir_element.location['x']).to eql 40
   end
 
   it "should have a height" do
@@ -181,13 +181,13 @@ describe "Element for Watir" do
     allow(watir_driver).to receive(:wd).and_return(watir_driver)
     expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
     expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
-    expect(watir_element.centre['y']).to be > watir_element.location_y
+    expect(watir_element.centre['y']).to be > watir_element.location['y']
   end
 
   it "should have a centre greater than x position" do
     allow(watir_driver).to receive(:wd).and_return(watir_driver)
     expect(watir_driver).to receive(:location).and_return({'y' => 80, 'x' => 40}).twice
     expect(watir_driver).to receive(:size).and_return({'width' => 30, 'height' => 20})
-    expect(watir_element.centre['x']).to be > watir_element.location_x
+    expect(watir_element.centre['x']).to be > watir_element.location['x']
   end
 end

--- a/spec/page-object/javascript_framework_facade_spec.rb
+++ b/spec/page-object/javascript_framework_facade_spec.rb
@@ -10,27 +10,27 @@ describe PageObject::JavascriptFrameworkFacade do
   
   it "should allow the selection of a javascript framework" do
     facade.framework = :jquery
-    facade.framework.should == :jquery
+    expect(facade.framework).to eql :jquery
   end
 
   it "should register the jQuery script builder" do
     facade.framework = :jquery
-    facade.script_builder.should == ::PageObject::Javascript::JQuery
+    expect(facade.script_builder).to eql ::PageObject::Javascript::JQuery
   end
 
   it "should return script for pending requests in jQuery" do
     facade.framework = :jquery
-    facade.pending_requests.should == 'return jQuery.active'
+    expect(facade.pending_requests).to eql 'return jQuery.active'
   end
 
   it "should register the Prototype script builder" do
     facade.framework = :prototype
-    facade.script_builder.should == ::PageObject::Javascript::Prototype
+    expect(facade.script_builder).to eql ::PageObject::Javascript::Prototype
   end
 
   it "should return script for pending requests in Prototype" do
     facade.framework = :prototype
-    facade.pending_requests.should == 'return Ajax.activeRequestCount'
+    expect(facade.pending_requests).to eql 'return Ajax.activeRequestCount'
   end
 
   it "should not allow you to set the framework to one it does not know about" do
@@ -46,7 +46,7 @@ describe PageObject::JavascriptFrameworkFacade do
     
     facade.add_framework(:blah, GoodFake)
     facade.framework = :blah
-    facade.pending_requests.should == "fake"
+    expect(facade.pending_requests).to eql "fake"
   end
 
   it "should not allow you to add a new javascript framework that is invalid" do

--- a/spec/page-object/loads_platform_spec.rb
+++ b/spec/page-object/loads_platform_spec.rb
@@ -11,7 +11,7 @@ describe TestLoadsPlatform do
     before { adapters[:browser_x] = mock_adapter(browser_x, :nom_nom_nom) }
 
     it "returns platform nom_nom_nom  when asked about browser_x" do
-      subject.load_platform(browser_x, adapters).should == :nom_nom_nom
+      expect(subject.load_platform(browser_x, adapters)).to eql :nom_nom_nom
     end
     
     context "when browser a is registered with platform boom_boom_boom" do
@@ -19,7 +19,7 @@ describe TestLoadsPlatform do
       before { adapters[:browser_a] = mock_adapter(browser_a, :boom_boom_boom) }
       
       it "should return platform nom_nom_nom when asked about browser_x" do
-        subject.load_platform(browser_x, adapters).should == :nom_nom_nom
+        expect(subject.load_platform(browser_x, adapters)).to eql :nom_nom_nom
       end
     end
   end
@@ -29,7 +29,7 @@ describe TestLoadsPlatform do
     before { adapters[:browser_n] = mock_adapter(browser_n, :boom_boom_boom) }
 
     it "should return platform boom_boom_boom" do
-      subject.load_platform(browser_n, adapters).should == :boom_boom_boom
+      expect(subject.load_platform(browser_n, adapters)).to eql :boom_boom_boom
     end
   end
 
@@ -46,7 +46,7 @@ describe TestLoadsPlatform do
       begin
         subject.load_platform(nil, {})
       rescue Exception => e
-        e.message.should == "#{basic_message}\nnil was passed to the PageObject constructor instead of a valid browser object."
+        expect(e.message).to eql "#{basic_message}\nnil was passed to the PageObject constructor instead of a valid browser object."
       end
     end
   end

--- a/spec/page-object/page-object_spec.rb
+++ b/spec/page-object/page-object_spec.rb
@@ -27,33 +27,33 @@ describe PageObject do
     it "should set a default page wait value" do
       PageObject.default_page_wait = 20
       wait = PageObject.instance_variable_get("@page_wait")
-      wait.should == 20
+      expect(wait).to eql 20
     end
 
     it "should provide the default page wait value" do
       PageObject.instance_variable_set("@page_wait", 10)
-      PageObject.default_page_wait.should == 10
+      expect(PageObject.default_page_wait).to eql 10
     end
 
     it "should default the page wait value to 30" do
       PageObject.instance_variable_set("@page_wait", nil)
-      PageObject.default_page_wait.should == 30
+      expect(PageObject.default_page_wait).to eql 30
     end
 
     it "should set the default element wait value" do
       PageObject.default_element_wait = 20
       wait = PageObject.instance_variable_get("@element_wait")
-      wait.should == 20
+      expect(wait).to eql 20
     end
 
     it "should provide the default element wait value" do
       PageObject.instance_variable_set("@element_wait", 10)
-      PageObject.default_element_wait.should == 10
+      expect(PageObject.default_element_wait).to eql 10
     end
 
     it "should default the element wait to 5" do
       PageObject.instance_variable_set("@element_wait", nil)
-      PageObject.default_element_wait.should == 5
+      expect(PageObject.default_element_wait).to eql 5
     end
   end
 
@@ -61,38 +61,39 @@ describe PageObject do
     it "should set the params value" do
       PageObjectTestPageObject.params = {:some => :value}
       params = PageObjectTestPageObject.instance_variable_get("@params")
-      params[:some].should == :value
+      expect(params[:some]).to eql :value
     end
 
     it "should provide the params value" do
       PageObjectTestPageObject.instance_variable_set("@params", {:value => :updated})
-      PageObjectTestPageObject.params[:value].should == :updated
+      expect(PageObjectTestPageObject.params[:value]).to eql :updated
     end
 
     it "should default the params to an empty hash" do
       PageObjectTestPageObject.instance_variable_set("@params", nil)
-      PageObjectTestPageObject.params.should == {}
+      expect(PageObjectTestPageObject.params).to eql Hash.new
     end
   end
 
   context "when created with a watir-webdriver browser" do
     it "should include the WatirPageObject module" do
-      watir_page_object.platform.should be_kind_of PageObject::Platforms::WatirWebDriver::PageObject
+      expect(watir_page_object.platform).to be_kind_of PageObject::Platforms::WatirWebDriver::PageObject
     end
   end
 
   context "when created with a selenium browser" do
     it "should include the SeleniumPageObject module" do
-      selenium_page_object.platform.should be_kind_of PageObject::Platforms::SeleniumWebDriver::PageObject
+      expect(selenium_page_object.platform).to be_kind_of PageObject::Platforms::SeleniumWebDriver::PageObject
     end
   end
   
   context "when created with a non_bundled adapter" do
     let(:custom_adapter) { mock_adapter(:custom_browser, CustomPlatform) }
+    
     it "should be an instance of whatever that objects adapter is" do
       mock_adapters({:custom_adapter=>custom_adapter})
       custom_page_object = PageObjectTestPageObject.new(:custom_browser)
-      custom_page_object.platform.should be custom_adapter.create_page_object
+      expect(custom_page_object.platform).to be custom_adapter.create_page_object
     end
   end
   
@@ -123,7 +124,7 @@ describe PageObject do
         end
         
         @page = CallbackPage.new(watir_browser)
-        @page.initialize_page_called.should be true
+        expect(@page.initialize_page_called).to be true
       end
 
       it "should call initialize_accessors if it exists" do
@@ -137,7 +138,7 @@ describe PageObject do
         end
 
         @page = CallbackPage.new(watir_browser)
-        @page.initialize_accessors_called.should be true
+        expect(@page.initialize_accessors_called).to be true
       end
 
       it "should call initialize_accessors before initialize_page if both exist" do
@@ -155,31 +156,31 @@ describe PageObject do
         end
 
         @page = CallbackPage.new(watir_browser)
-        @page.initialize_accessors.usec.should be <= @page.initialize_page.usec
+        expect(@page.initialize_accessors.usec).to be <= @page.initialize_page.usec
       end
 
       it "should know which element has focus" do
         watir_browser.should_receive(:execute_script).and_return(watir_browser)
         watir_browser.should_receive(:tag_name).twice.and_return(:input)
         watir_browser.should_receive(:type).and_return(:submit)
-        watir_page_object.element_with_focus.class.should == PageObject::Elements::Button
+        expect(watir_page_object.element_with_focus.class).to eql PageObject::Elements::Button
       end
     end
     
     context "when using WatirPageObject" do
       it "should display the page text" do
         watir_browser.should_receive(:text).and_return("browser text")
-        watir_page_object.text.should == "browser text"
+        expect(watir_page_object.text).to eql "browser text"
       end
 
       it "should display the html of the page" do
         watir_browser.should_receive(:html).and_return("<html>Some Sample HTML</html>")
-        watir_page_object.html.should == "<html>Some Sample HTML</html>"
+        expect(watir_page_object.html).to eql "<html>Some Sample HTML</html>"
       end
 
       it "should display the title of the page" do
         watir_browser.should_receive(:title).and_return("I am the title of a page")
-        watir_page_object.title.should == "I am the title of a page"
+        expect(watir_page_object.title).to eql "I am the title of a page"
       end
 
       it "should be able to navigate to a page" do
@@ -231,7 +232,7 @@ describe PageObject do
 
       it "should execute javascript on the browser" do
         watir_browser.should_receive(:execute_script).and_return("abc")
-        watir_page_object.execute_script("333").should == "abc"
+        expect(watir_page_object.execute_script("333")).to eql "abc"
       end
       
       it "should convert a modal popup to a window" do
@@ -268,7 +269,7 @@ describe PageObject do
       
       it "should know its' current url" do
         watir_browser.should_receive(:url).and_return("cheezyworld.com")
-        watir_page_object.current_url.should == "cheezyworld.com"
+        expect(watir_page_object.current_url).to eql "cheezyworld.com"
       end
       
       it "should know how to clear all of the cookies from the browser" do
@@ -287,17 +288,17 @@ describe PageObject do
     context "when using SeleniumPageObject" do
       it "should display the page text" do
         selenium_browser.stub_chain(:find_element, :text).and_return("browser text")
-        selenium_page_object.text.should == "browser text"
+        expect(selenium_page_object.text).to eql "browser text"
       end
 
       it "should display the html of the page" do
         selenium_browser.should_receive(:page_source).and_return("<html>Some Sample HTML</html>")
-        selenium_page_object.html.should == "<html>Some Sample HTML</html>"
+        expect(selenium_page_object.html).to eql "<html>Some Sample HTML</html>"
       end
 
       it "should display the title of the page" do
         selenium_browser.should_receive(:title).and_return("I am the title of a page")
-        selenium_page_object.title.should == "I am the title of a page"
+        expect(selenium_page_object.title).to eql "I am the title of a page"
       end
 
       it "should be able to navigate to a page" do
@@ -348,7 +349,7 @@ describe PageObject do
       
       it "should execute javascript on the browser" do
         selenium_browser.should_receive(:execute_script).and_return("abc")
-        selenium_page_object.execute_script("333").should == "abc"
+        expect(selenium_page_object.execute_script("333")).to eql "abc"
       end
 
       it "should switch to a new window with a given title" do
@@ -387,7 +388,7 @@ describe PageObject do
       
       it "should know its' current url" do
         selenium_browser.should_receive(:current_url).and_return("cheezyworld.com")
-        selenium_page_object.current_url.should == "cheezyworld.com"
+        expect(selenium_page_object.current_url).to eql "cheezyworld.com"
       end
       
       it "should clear all of the cookies from the browser" do

--- a/spec/page-object/page-object_spec.rb
+++ b/spec/page-object/page-object_spec.rb
@@ -15,12 +15,12 @@ describe PageObject do
 
   context "setting values on the PageObject module" do
     it "should set the javascript framework" do
-      PageObject::JavascriptFrameworkFacade.should_receive(:framework=)
+      expect(PageObject::JavascriptFrameworkFacade).to receive(:framework=)
       PageObject.javascript_framework = :foo
     end
 
     it "should add a new Javascript Framework" do
-      PageObject::JavascriptFrameworkFacade.should_receive(:add_framework)
+      expect(PageObject::JavascriptFrameworkFacade).to receive(:add_framework)
       PageObject.add_framework(:foo, :bar)
     end
 
@@ -108,8 +108,8 @@ describe PageObject do
   describe "page level functionality" do
     context "for all drivers" do
       it "should try a second time after sleeping when attach to window fails" do
-        watir_page_object.platform.should_receive(:attach_to_window).once.and_throw "error"
-        watir_page_object.platform.should_receive(:attach_to_window)
+        expect(watir_page_object.platform).to receive(:attach_to_window).once.and_throw "error"
+        expect(watir_page_object.platform).to receive(:attach_to_window)
         watir_page_object.attach_to_window("blah")
       end
       
@@ -160,245 +160,245 @@ describe PageObject do
       end
 
       it "should know which element has focus" do
-        watir_browser.should_receive(:execute_script).and_return(watir_browser)
-        watir_browser.should_receive(:tag_name).twice.and_return(:input)
-        watir_browser.should_receive(:type).and_return(:submit)
+        expect(watir_browser).to receive(:execute_script).and_return(watir_browser)
+        expect(watir_browser).to receive(:tag_name).twice.and_return(:input)
+        expect(watir_browser).to receive(:type).and_return(:submit)
         expect(watir_page_object.element_with_focus.class).to eql PageObject::Elements::Button
       end
     end
     
     context "when using WatirPageObject" do
       it "should display the page text" do
-        watir_browser.should_receive(:text).and_return("browser text")
+        expect(watir_browser).to receive(:text).and_return("browser text")
         expect(watir_page_object.text).to eql "browser text"
       end
 
       it "should display the html of the page" do
-        watir_browser.should_receive(:html).and_return("<html>Some Sample HTML</html>")
+        expect(watir_browser).to receive(:html).and_return("<html>Some Sample HTML</html>")
         expect(watir_page_object.html).to eql "<html>Some Sample HTML</html>"
       end
 
       it "should display the title of the page" do
-        watir_browser.should_receive(:title).and_return("I am the title of a page")
+        expect(watir_browser).to receive(:title).and_return("I am the title of a page")
         expect(watir_page_object.title).to eql "I am the title of a page"
       end
 
       it "should be able to navigate to a page" do
-        watir_browser.should_receive(:goto).with("cheezyworld.com")
+        expect(watir_browser).to receive(:goto).with("cheezyworld.com")
         watir_page_object.navigate_to("cheezyworld.com")
       end
 
       it "should wait until a block returns true" do
-        watir_browser.should_receive(:wait_until).with(5, "too long")
+        expect(watir_browser).to receive(:wait_until).with(5, "too long")
         watir_page_object.wait_until(5, "too long")
       end
 
       it "should use the overriden timeout value when set" do
         PageObject.default_page_wait = 10
-        watir_browser.should_receive(:wait_until).with(10, nil)
+        expect(watir_browser).to receive(:wait_until).with(10, nil)
         watir_page_object.wait_until
       end
 
       it "should wait until there are no pending ajax requests" do
-        PageObject::JavascriptFrameworkFacade.should_receive(:pending_requests).and_return('pending requests')
-        watir_browser.should_receive(:execute_script).with('pending requests').and_return(0)
+        expect(PageObject::JavascriptFrameworkFacade).to receive(:pending_requests).and_return('pending requests')
+        expect(watir_browser).to receive(:execute_script).with('pending requests').and_return(0)
         watir_page_object.wait_for_ajax
       end
 
       it "should override alert popup behavior" do
-        watir_browser.should_receive(:alert).exactly(3).times.and_return(watir_browser)
-        watir_browser.should_receive(:exists?).and_return(true)
-        watir_browser.should_receive(:text)
-        watir_browser.should_receive(:ok)
+        expect(watir_browser).to receive(:alert).exactly(3).times.and_return(watir_browser)
+        expect(watir_browser).to receive(:exists?).and_return(true)
+        expect(watir_browser).to receive(:text)
+        expect(watir_browser).to receive(:ok)
         watir_page_object.alert do
         end
       end
 
       it "should override confirm popup behavior" do
-        watir_browser.should_receive(:alert).exactly(3).times.and_return(watir_browser)
-        watir_browser.should_receive(:exists?).and_return(true)
-        watir_browser.should_receive(:text)
-        watir_browser.should_receive(:ok)
+        expect(watir_browser).to receive(:alert).exactly(3).times.and_return(watir_browser)
+        expect(watir_browser).to receive(:exists?).and_return(true)
+        expect(watir_browser).to receive(:text)
+        expect(watir_browser).to receive(:ok)
         watir_page_object.confirm(true) do
         end
       end
 
       it "should override prompt popup behavior" do
-        watir_browser.should_receive(:wd).twice.and_return(watir_browser)
-        watir_browser.should_receive(:execute_script).twice
+        expect(watir_browser).to receive(:wd).twice.and_return(watir_browser)
+        expect(watir_browser).to receive(:execute_script).twice
         watir_page_object.prompt("blah") do
         end
       end
 
       it "should execute javascript on the browser" do
-        watir_browser.should_receive(:execute_script).and_return("abc")
+        expect(watir_browser).to receive(:execute_script).and_return("abc")
         expect(watir_page_object.execute_script("333")).to eql "abc"
       end
       
       it "should convert a modal popup to a window" do
-        watir_browser.should_receive(:execute_script)
+        expect(watir_browser).to receive(:execute_script)
         watir_page_object.modal_dialog {}
       end
       
       it "should switch to a new window with a given title" do
-        watir_browser.should_receive(:window).with(:title => /My\ Title/).and_return(watir_browser)
-        watir_browser.should_receive(:use)
+        expect(watir_browser).to receive(:window).with(:title => /My\ Title/).and_return(watir_browser)
+        expect(watir_browser).to receive(:use)
         watir_page_object.attach_to_window(:title => "My Title")
       end
       
       it "should switch to a new window with a given url" do
-        watir_browser.should_receive(:window).with(:url => /success\.html/).and_return(watir_browser)
-        watir_browser.should_receive(:use)
+        expect(watir_browser).to receive(:window).with(:url => /success\.html/).and_return(watir_browser)
+        expect(watir_browser).to receive(:use)
         watir_page_object.attach_to_window(:url => "success.html")
       end
       
       it "should refresh the page contents" do
-        watir_browser.should_receive(:refresh)
+        expect(watir_browser).to receive(:refresh)
         watir_page_object.refresh
       end
 
       it "should know how to go back" do
-        watir_browser.should_receive(:back)
+        expect(watir_browser).to receive(:back)
         watir_page_object.back
       end
 
       it "should know how to go forward" do
-        watir_browser.should_receive(:forward)
+        expect(watir_browser).to receive(:forward)
         watir_page_object.forward
       end
       
       it "should know its' current url" do
-        watir_browser.should_receive(:url).and_return("cheezyworld.com")
+        expect(watir_browser).to receive(:url).and_return("cheezyworld.com")
         expect(watir_page_object.current_url).to eql "cheezyworld.com"
       end
       
       it "should know how to clear all of the cookies from the browser" do
-        watir_browser.should_receive(:cookies).and_return(watir_browser)
-        watir_browser.should_receive(:clear)
+        expect(watir_browser).to receive(:cookies).and_return(watir_browser)
+        expect(watir_browser).to receive(:clear)
         watir_page_object.clear_cookies
       end
       
       it "should be able to save a screenshot" do
-        watir_browser.should_receive(:wd).and_return(watir_browser)
-        watir_browser.should_receive(:save_screenshot)
+        expect(watir_browser).to receive(:wd).and_return(watir_browser)
+        expect(watir_browser).to receive(:save_screenshot)
         watir_page_object.save_screenshot("test.png")
       end
     end
 
     context "when using SeleniumPageObject" do
       it "should display the page text" do
-        selenium_browser.stub_chain(:find_element, :text).and_return("browser text")
+        expect(selenium_browser).to receive_messages(find_element: selenium_browser, text: 'browser text')
         expect(selenium_page_object.text).to eql "browser text"
       end
 
       it "should display the html of the page" do
-        selenium_browser.should_receive(:page_source).and_return("<html>Some Sample HTML</html>")
+        expect(selenium_browser).to receive(:page_source).and_return("<html>Some Sample HTML</html>")
         expect(selenium_page_object.html).to eql "<html>Some Sample HTML</html>"
       end
 
       it "should display the title of the page" do
-        selenium_browser.should_receive(:title).and_return("I am the title of a page")
+        expect(selenium_browser).to receive(:title).and_return("I am the title of a page")
         expect(selenium_page_object.title).to eql "I am the title of a page"
       end
 
       it "should be able to navigate to a page" do
-        selenium_browser.stub_chain(:navigate, :to).with('cheezyworld.com')
+        expect(selenium_browser).to receive_messages(navigate: selenium_browser, to: 'cheezyworld.com')
         selenium_page_object.navigate_to('cheezyworld.com')
       end
 
       it "should wait until a block returns true" do
         wait = double('wait')
-        Selenium::WebDriver::Wait.should_receive(:new).with({:timeout => 5, :message => 'too long'}).and_return(wait)
-        wait.should_receive(:until)
+        expect(Selenium::WebDriver::Wait).to receive(:new).with({:timeout => 5, :message => 'too long'}).and_return(wait)
+        expect(wait).to receive(:until)
         selenium_page_object.wait_until(5, 'too long')
       end
 
       it "should wait until there are no pending ajax requests" do
-        PageObject::JavascriptFrameworkFacade.should_receive(:pending_requests).and_return('pending requests')
-        selenium_browser.should_receive(:execute_script).with('pending requests').and_return(0)
+        expect(PageObject::JavascriptFrameworkFacade).to receive(:pending_requests).and_return('pending requests')
+        expect(selenium_browser).to receive(:execute_script).with('pending requests').and_return(0)
         selenium_page_object.wait_for_ajax
       end
 
       it "should override alert popup behavior" do
-        selenium_browser.should_receive(:switch_to).and_return(selenium_browser)
-        selenium_browser.should_receive(:alert).and_return(selenium_browser)
-        selenium_browser.should_receive(:text)
-        selenium_browser.should_receive(:accept)
+        expect(selenium_browser).to receive(:switch_to).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:alert).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:text)
+        expect(selenium_browser).to receive(:accept)
         selenium_page_object.alert do
         end
       end
 
       it "should override confirm popup behavior" do
-        selenium_browser.should_receive(:switch_to).and_return(selenium_browser)
-        selenium_browser.should_receive(:alert).and_return(selenium_browser)
-        selenium_browser.should_receive(:text)
-        selenium_browser.should_receive(:accept)
+        expect(selenium_browser).to receive(:switch_to).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:alert).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:text)
+        expect(selenium_browser).to receive(:accept)
         selenium_page_object.confirm(true) do
         end
       end
       it "should override prompt popup behavior" do
-        selenium_browser.should_receive(:execute_script).twice
+        expect(selenium_browser).to receive(:execute_script).twice
         selenium_page_object.prompt("blah") do
         end
       end
       
       it "should convert a modal popup to a window" do
-        selenium_browser.should_receive(:execute_script)
+        expect(selenium_browser).to receive(:execute_script)
         selenium_page_object.modal_dialog {}
       end
       
       it "should execute javascript on the browser" do
-        selenium_browser.should_receive(:execute_script).and_return("abc")
+        expect(selenium_browser).to receive(:execute_script).and_return("abc")
         expect(selenium_page_object.execute_script("333")).to eql "abc"
       end
 
       it "should switch to a new window with a given title" do
-        selenium_browser.should_receive(:window_handles).and_return(["win1"])
-        selenium_browser.should_receive(:switch_to).twice.and_return(selenium_browser)
-        selenium_browser.should_receive(:window).twice.with("win1").and_return(selenium_browser)
-        selenium_browser.should_receive(:title).and_return("My Title")
+        expect(selenium_browser).to receive(:window_handles).and_return(["win1"])
+        expect(selenium_browser).to receive(:switch_to).twice.and_return(selenium_browser)
+        expect(selenium_browser).to receive(:window).twice.with("win1").and_return(selenium_browser)
+        expect(selenium_browser).to receive(:title).and_return("My Title")
         selenium_page_object.attach_to_window(:title => "My Title")
       end
       
       it "should switch to a new window with a given url" do
-        selenium_browser.should_receive(:window_handles).and_return(["win1"])
-        selenium_browser.should_receive(:switch_to).twice.and_return(selenium_browser)
-        selenium_browser.should_receive(:window).twice.with("win1").and_return(selenium_browser)
-        selenium_browser.should_receive(:current_url).and_return("page.html")
+        expect(selenium_browser).to receive(:window_handles).and_return(["win1"])
+        expect(selenium_browser).to receive(:switch_to).twice.and_return(selenium_browser)
+        expect(selenium_browser).to receive(:window).twice.with("win1").and_return(selenium_browser)
+        expect(selenium_browser).to receive(:current_url).and_return("page.html")
         selenium_page_object.attach_to_window(:url => "page.html")
       end
       
       it "should refresh the page contents" do
-        selenium_browser.should_receive(:navigate).and_return(selenium_browser)
-        selenium_browser.should_receive(:refresh)
+        expect(selenium_browser).to receive(:navigate).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:refresh)
         selenium_page_object.refresh
       end
       
       it "should know how to go back" do
-        selenium_browser.should_receive(:navigate).and_return(selenium_browser)
-        selenium_browser.should_receive(:back)
+        expect(selenium_browser).to receive(:navigate).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:back)
         selenium_page_object.back
       end
       
       it "should know how to go forward" do
-        selenium_browser.should_receive(:navigate).and_return(selenium_browser)
-        selenium_browser.should_receive(:forward)
+        expect(selenium_browser).to receive(:navigate).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:forward)
         selenium_page_object.forward
       end
       
       it "should know its' current url" do
-        selenium_browser.should_receive(:current_url).and_return("cheezyworld.com")
+        expect(selenium_browser).to receive(:current_url).and_return("cheezyworld.com")
         expect(selenium_page_object.current_url).to eql "cheezyworld.com"
       end
       
       it "should clear all of the cookies from the browser" do
-        selenium_browser.should_receive(:manage).and_return(selenium_browser)
-        selenium_browser.should_receive(:delete_all_cookies)
+        expect(selenium_browser).to receive(:manage).and_return(selenium_browser)
+        expect(selenium_browser).to receive(:delete_all_cookies)
         selenium_page_object.clear_cookies
       end
       
       it "should be able to save a screenshot" do
-        selenium_browser.should_receive(:save_screenshot)
+        expect(selenium_browser).to receive(:save_screenshot)
         selenium_page_object.save_screenshot("test.png")
       end
     end

--- a/spec/page-object/page_factory_spec.rb
+++ b/spec/page-object/page_factory_spec.rb
@@ -54,7 +54,7 @@ describe PageObject::PageFactory do
   end
 
   it "should create a new page object and execute a block" do
-    @world.browser.should_not_receive(:goto)
+    expect(@world.browser).not_to receive(:goto)
     @world.on_page FactoryTestPage do |page|
       expect(page).to be_instance_of FactoryTestPage
     end
@@ -67,7 +67,7 @@ describe PageObject::PageFactory do
   end
 
   it "should create a new page object and execute a block using 'on'" do
-    @world.browser.should_not_receive(:goto)
+    expect(@world.browser).not_to receive(:goto)
     @world.on FactoryTestPage do |page|
       expect(page).to be_instance_of FactoryTestPage
     end
@@ -80,7 +80,7 @@ describe PageObject::PageFactory do
   end
 
   it "should create and visit a new page" do
-    @world.browser.should_receive(:goto).exactly(3).times
+    expect(@world.browser).to receive(:goto).exactly(3).times
     @world.visit_page FactoryTestPage do |page|
       expect(page).to be_instance_of FactoryTestPage
     end
@@ -93,7 +93,7 @@ describe PageObject::PageFactory do
   end
 
   it "should merge params with the class level params if provided when visiting" do
-    @world.browser.should_receive(:goto)
+    expect(@world.browser).to receive(:goto)
     FactoryTestPage.params = {:initial => :value}
     @world.visit_page(FactoryTestPage, :using_params => {:new_value => :merged})
     merged = FactoryTestPage.instance_variable_get("@merged_params")
@@ -106,7 +106,7 @@ describe PageObject::PageFactory do
       include PageObject
       page_url "http://google.com/<%=params[:value]%>"
     end
-    @world.browser.should_receive(:goto).with("http://google.com/PageObject")
+    expect(@world.browser).to receive(:goto).with("http://google.com/PageObject")
     @world.visit_page(PageUsingParams, :using_params => {:value => 'PageObject'})
   end
 
@@ -115,12 +115,12 @@ describe PageObject::PageFactory do
       include PageObject
       page_url "http://google.com/#{1+2}/<%=params[:value]%>"
     end
-    @world.browser.should_receive(:goto).with("http://google.com/3/PageObject")
+    expect(@world.browser).to receive(:goto).with("http://google.com/3/PageObject")
     @world.visit_page(PageUsingParmsAndInterpolated, :using_params => {:value => 'PageObject'})
   end
 
   it "should create and visit a new page using 'visit'" do
-    @world.browser.should_receive(:goto).exactly(3).times
+    expect(@world.browser).to receive(:goto).exactly(3).times
     @world.visit FactoryTestPage do |page|
       expect(page).to be_instance_of FactoryTestPage
     end
@@ -133,7 +133,7 @@ describe PageObject::PageFactory do
   end
 
   it "should create and visit a new page when url is defined as 'direct_url'" do
-    @world.browser.should_receive(:goto)
+    expect(@world.browser).to receive(:goto)
     @world.visit TestPageWithDirectUrl do |page|
       expect(page).to be_instance_of TestPageWithDirectUrl
     end
@@ -206,8 +206,8 @@ describe PageObject::PageFactory do
     pages = [[FactoryTestPage, :a_method], [AnotherPage, :b_method]]
     PageObject::PageFactory.routes = {:default => pages}
     fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:a_method)
+    expect(FactoryTestPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:a_method)
     expect(@world.navigate_to(AnotherPage).class).to eql AnotherPage
   end
 
@@ -215,8 +215,8 @@ describe PageObject::PageFactory do
     pages = [[FactoryTestPage, :a_method, 'blah'], [AnotherPage, :b_method]]
     PageObject::PageFactory.routes = {:default => pages}
     fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:a_method).with('blah')
+    expect(FactoryTestPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:a_method).with('blah')
     expect(@world.navigate_to(AnotherPage).class).to eql AnotherPage
   end
 
@@ -230,8 +230,8 @@ describe PageObject::PageFactory do
       :default => [[FactoryTestPage, :a_method], [AnotherPage, :b_method]]
     }
     fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:respond_to?).with(:a_method).and_return(false)
+    expect(FactoryTestPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:respond_to?).with(:a_method).and_return(false)
     expect { @world.navigate_to(AnotherPage) }.to raise_error
   end
 
@@ -244,13 +244,13 @@ describe PageObject::PageFactory do
 
     @world.current_page = FactoryTestPage.new(@world.browser)
     f_page = FactoryTestPage.new(@world.browser)
-    FactoryTestPage.should_receive(:new).and_return(f_page)
-    f_page.should_receive(:respond_to?).with(:a_method).and_return(true)
-    f_page.should_receive(:a_method)
+    expect(FactoryTestPage).to receive(:new).and_return(f_page)
+    expect(f_page).to receive(:respond_to?).with(:a_method).and_return(true)
+    expect(f_page).to receive(:a_method)
     a_page = AnotherPage.new(@world.browser)
-    AnotherPage.should_receive(:new).and_return(a_page)
-    a_page.should_receive(:respond_to?).with(:b_method).and_return(true)
-    a_page.should_receive(:b_method)
+    expect(AnotherPage).to receive(:new).and_return(a_page)
+    expect(a_page).to receive(:respond_to?).with(:b_method).and_return(true)
+    expect(a_page).to receive(:b_method)
     expect(@world.continue_navigation_to(YetAnotherPage).class).to eql YetAnotherPage
   end
 end

--- a/spec/page-object/page_factory_spec.rb
+++ b/spec/page-object/page_factory_spec.rb
@@ -50,45 +50,45 @@ describe PageObject::PageFactory do
     class NoPO
     end
     @world.on(NoPO)
-    @world.super_called.should be true
+    expect(@world.super_called).to be true
   end
 
   it "should create a new page object and execute a block" do
     @world.browser.should_not_receive(:goto)
     @world.on_page FactoryTestPage do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.on_page "FactoryTestPage" do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.on_page "ContainingModule::PageInsideModule" do |page|
-      page.should be_instance_of ContainingModule::PageInsideModule
+      expect(page).to be_instance_of ContainingModule::PageInsideModule
     end
   end
 
   it "should create a new page object and execute a block using 'on'" do
     @world.browser.should_not_receive(:goto)
     @world.on FactoryTestPage do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.on "FactoryTestPage" do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.on "ContainingModule::PageInsideModule" do |page|
-      page.should be_instance_of ContainingModule::PageInsideModule
+      expect(page).to be_instance_of ContainingModule::PageInsideModule
     end
   end
 
   it "should create and visit a new page" do
     @world.browser.should_receive(:goto).exactly(3).times
     @world.visit_page FactoryTestPage do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.visit_page "FactoryTestPage" do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.visit_page "ContainingModule::PageInsideModule" do |page|
-      page.should be_instance_of ContainingModule::PageInsideModule
+      expect(page).to be_instance_of ContainingModule::PageInsideModule
     end
   end
 
@@ -97,8 +97,8 @@ describe PageObject::PageFactory do
     FactoryTestPage.params = {:initial => :value}
     @world.visit_page(FactoryTestPage, :using_params => {:new_value => :merged})
     merged = FactoryTestPage.instance_variable_get("@merged_params")
-    merged[:initial].should == :value
-    merged[:new_value].should == :merged
+    expect(merged[:initial]).to eql :value
+    expect(merged[:new_value]).to eql :merged
   end
 
   it "should use the params in the url when they are provided" do
@@ -122,27 +122,27 @@ describe PageObject::PageFactory do
   it "should create and visit a new page using 'visit'" do
     @world.browser.should_receive(:goto).exactly(3).times
     @world.visit FactoryTestPage do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.visit "FactoryTestPage" do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
     end
     @world.visit "ContainingModule::PageInsideModule" do |page|
-      page.should be_instance_of ContainingModule::PageInsideModule
+      expect(page).to be_instance_of ContainingModule::PageInsideModule
     end
   end
 
   it "should create and visit a new page when url is defined as 'direct_url'" do
     @world.browser.should_receive(:goto)
     @world.visit TestPageWithDirectUrl do |page|
-      page.should be_instance_of TestPageWithDirectUrl
+      expect(page).to be_instance_of TestPageWithDirectUrl
     end
   end
   
   it "should set an instance variable that can be used outside of the block" do
     page = @world.on_page FactoryTestPage
     current_page = @world.instance_variable_get "@current_page"
-    current_page.should === page
+    expect(current_page).to equal page
   end
 
   it "should not execute block if page is not @current_page" do
@@ -161,9 +161,9 @@ describe PageObject::PageFactory do
   it "should return the @current_page if asking for another page" do
     expected = TestPageWithDirectUrl.new(@world.browser)
     @world.instance_variable_set "@current_page", expected
-    @world.if_page(FactoryTestPage).should == expected
-    @world.if_page("FactoryTestPage").should == expected
-    @world.if_page("ContainingModule::PageInsideModule").should == expected
+    expect(@world.if_page(FactoryTestPage)).to eql expected
+    expect(@world.if_page("FactoryTestPage")).to eql expected
+    expect(@world.if_page("ContainingModule::PageInsideModule")).to eql expected
   end
 
   it "should execute the block when we ask if it is the correct page" do
@@ -171,25 +171,25 @@ describe PageObject::PageFactory do
     
     done = false
     @world.if_page(FactoryTestPage) do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
       done = true 
     end
-    done.should be true
+    expect(done).to be true
     
     done = false
     @world.if_page("FactoryTestPage") do |page|
-      page.should be_instance_of FactoryTestPage
+      expect(page).to be_instance_of FactoryTestPage
       done = true
     end
-    done.should be true
+    expect(done).to be true
     
     done = false
     @world.instance_variable_set "@current_page", ContainingModule::PageInsideModule.new(@world.browser) 
     @world.if_page("ContainingModule::PageInsideModule") do |page|
-      page.should be_instance_of ContainingModule::PageInsideModule
+      expect(page).to be_instance_of ContainingModule::PageInsideModule
       done = true
     end
-    done.should be true
+    expect(done).to be true
   end
 
   it "should raise an error when you do not provide a default route" do
@@ -199,7 +199,7 @@ describe PageObject::PageFactory do
   it "should store the routes" do
     routes = ['a', 'b', 'c']
     PageObject::PageFactory.routes = {:default => routes}
-    PageObject::PageFactory.routes[:default].should == routes
+    expect(PageObject::PageFactory.routes[:default]).to eql routes
   end
 
   it "should navigate to a page calling the default methods" do
@@ -208,7 +208,7 @@ describe PageObject::PageFactory do
     fake_page = double('a_page')
     FactoryTestPage.should_receive(:new).and_return(fake_page)
     fake_page.should_receive(:a_method)
-    @world.navigate_to(AnotherPage).class.should == AnotherPage
+    expect(@world.navigate_to(AnotherPage).class).to eql AnotherPage
   end
 
   it "should pass parameters to methods when navigating" do
@@ -217,7 +217,7 @@ describe PageObject::PageFactory do
     fake_page = double('a_page')
     FactoryTestPage.should_receive(:new).and_return(fake_page)
     fake_page.should_receive(:a_method).with('blah')
-    @world.navigate_to(AnotherPage).class.should == AnotherPage
+    expect(@world.navigate_to(AnotherPage).class).to eql AnotherPage
   end
 
   it "should fail when it does not find a proper route" do
@@ -251,6 +251,6 @@ describe PageObject::PageFactory do
     AnotherPage.should_receive(:new).and_return(a_page)
     a_page.should_receive(:respond_to?).with(:b_method).and_return(true)
     a_page.should_receive(:b_method)
-    @world.continue_navigation_to(YetAnotherPage).class.should == YetAnotherPage
+    expect(@world.continue_navigation_to(YetAnotherPage).class).to eql YetAnotherPage
   end
 end

--- a/spec/page-object/page_factory_spec.rb
+++ b/spec/page-object/page_factory_spec.rb
@@ -235,22 +235,4 @@ describe PageObject::PageFactory do
     expect { @world.navigate_to(AnotherPage) }.to raise_error
   end
 
-  it "should know how to continue routing from a location" do
-    PageObject::PageFactory.routes = {
-      :default => [[FactoryTestPage, :a_method],
-                   [AnotherPage, :b_method],
-                   [YetAnotherPage, :c_method]]
-    }
-
-    @world.current_page = FactoryTestPage.new(@world.browser)
-    f_page = FactoryTestPage.new(@world.browser)
-    expect(FactoryTestPage).to receive(:new).and_return(f_page)
-    expect(f_page).to receive(:respond_to?).with(:a_method).and_return(true)
-    expect(f_page).to receive(:a_method)
-    a_page = AnotherPage.new(@world.browser)
-    expect(AnotherPage).to receive(:new).and_return(a_page)
-    expect(a_page).to receive(:respond_to?).with(:b_method).and_return(true)
-    expect(a_page).to receive(:b_method)
-    expect(@world.continue_navigation_to(YetAnotherPage).class).to eql YetAnotherPage
-  end
 end

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -17,106 +17,106 @@ describe PageObject::PagePopulator  do
   let(:page_object) { PageObjectTestPageObject.new(browser) }
 
   it "should set a value in a text field" do
-    page_object.should_receive(:tf=).with('value')
-    page_object.stub(:is_enabled?).and_return(true)
+    expect(page_object).to receive(:tf=).with('value')
+    allow(page_object).to receive(:is_enabled?).and_return(true)
     page_object.populate_page_with('tf' => 'value')
   end
 
   it "should not set a value in a text field if it is not found on the page" do
-    browser.should_not_receive(:text_field)
+    expect(browser).not_to receive(:text_field)
     page_object.populate_page_with('coffee' => 'value')
   end
 
   it "should not populate a text field when it is disabled" do
-    page_object.should_not_receive(:tf=)
-    page_object.should_receive(:tf_element).twice.and_return(browser)
-    browser.should_receive(:enabled?).and_return(false)
-    browser.should_receive(:tag_name).and_return('input')
+    expect(page_object).not_to receive(:tf=)
+    expect(page_object).to receive(:tf_element).twice.and_return(browser)
+    expect(browser).to receive(:enabled?).and_return(false)
+    expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('tf' => true)
   end
 
   it "should not populate a text field when it is not visible" do
-    page_object.should_not_receive(:tf=)
-    page_object.should_receive(:tf_element).twice.and_return(browser)
-    browser.should_receive(:enabled?).and_return(true)
-    browser.should_receive(:visible?).and_return(false)
-    browser.should_receive(:tag_name).and_return('input')
+    expect(page_object).not_to receive(:tf=)
+    expect(page_object).to receive(:tf_element).twice.and_return(browser)
+    expect(browser).to receive(:enabled?).and_return(true)
+    expect(browser).to receive(:visible?).and_return(false)
+    expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('tf' => true)
   end
 
   it "should set a value in a text area" do
-    page_object.should_receive(:ta=).with('value')
-    page_object.should_receive(:ta_element).and_return(browser)
-    browser.should_receive(:tag_name).and_return('textarea')
+    expect(page_object).to receive(:ta=).with('value')
+    expect(page_object).to receive(:ta_element).and_return(browser)
+    expect(browser).to receive(:tag_name).and_return('textarea')
     page_object.populate_page_with('ta' => 'value')
   end
 
   it "should set a value in a select list" do
-    page_object.should_receive(:sl=).with('value')
-    page_object.stub(:is_enabled?).and_return(true)
+    expect(page_object).to receive(:sl=).with('value')
+    allow(page_object).to receive(:is_enabled?).and_return(true)
     page_object.populate_page_with('sl' => 'value')
   end
 
   it "should set a value in a file field" do
-    page_object.should_receive(:ff=).with('value')
-    page_object.stub(:is_enabled?).and_return(true)
+    expect(page_object).to receive(:ff=).with('value')
+    allow(page_object).to receive(:is_enabled?).and_return(true)
     page_object.populate_page_with('ff' => 'value')
   end
 
   it "should check a checkbox to true is specified" do
-    page_object.should_receive(:check_cb)
-    page_object.stub(:is_enabled?).and_return(true)
+    expect(page_object).to receive(:check_cb)
+    allow(page_object).to receive(:is_enabled?).and_return(true)
     page_object.populate_page_with('cb' => true)
   end
 
   it "should uncheck a checkbox to false is specified" do
-    page_object.should_receive(:uncheck_cb)
-    page_object.stub(:is_enabled?).and_return(true)
+    expect(page_object).to receive(:uncheck_cb)
+    allow(page_object).to receive(:is_enabled?).and_return(true)
     page_object.populate_page_with('cb' => false)
   end
 
   it "should select a radio button when true is specified" do
-    page_object.should_receive(:select_rb)
-    page_object.stub(:is_enabled?).and_return(true)
+    expect(page_object).to receive(:select_rb)
+    allow(page_object).to receive(:is_enabled?).and_return(true)
     page_object.populate_page_with('rb' => true)
   end
 
   it "should select the correct element from a radio button group" do
-    page_object.should_receive(:select_rbg).with('blah')
+    expect(page_object).to receive(:select_rbg).with('blah')
     page_object.populate_page_with('rbg' => 'blah')
   end
 
   it "should not populate a checkbox if it is disabled" do
-    page_object.should_not_receive(:check_cb)
-    page_object.should_receive(:cb_element).twice.and_return(browser)
-    browser.should_receive(:enabled?).and_return(false)
-    browser.should_receive(:tag_name).and_return('input')
+    expect(page_object).not_to receive(:check_cb)
+    expect(page_object).to receive(:cb_element).twice.and_return(browser)
+    expect(browser).to receive(:enabled?).and_return(false)
+    expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('cb' => true)
   end
 
   it "should not populate a checkbox if it is not visible" do
-    page_object.should_not_receive(:check_cb)
-    page_object.should_receive(:cb_element).twice.and_return(browser)
-    browser.should_receive(:enabled?).and_return(true)
-    browser.should_receive(:visible?).and_return(false)
-    browser.should_receive(:tag_name).and_return('input')
+    expect(page_object).not_to receive(:check_cb)
+    expect(page_object).to receive(:cb_element).twice.and_return(browser)
+    expect(browser).to receive(:enabled?).and_return(true)
+    expect(browser).to receive(:visible?).and_return(false)
+    expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('cb' => true)
   end
 
   it "should not populate a radio button when it is disabled" do
-    page_object.should_not_receive(:select_rb)
-    page_object.should_receive(:rb_element).twice.and_return(browser)
-    browser.should_receive(:enabled?).and_return(false)
-    browser.should_receive(:tag_name).and_return('input')
+    expect(page_object).not_to receive(:select_rb)
+    expect(page_object).to receive(:rb_element).twice.and_return(browser)
+    expect(browser).to receive(:enabled?).and_return(false)
+    expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('rb' => true)
   end
 
   it "should not populate a radio button when it is not visible" do
-    page_object.should_not_receive(:select_rb)
-    page_object.should_receive(:rb_element).twice.and_return(browser)
-    browser.should_receive(:enabled?).and_return(true)
-    browser.should_receive(:visible?).and_return(false)
-    browser.should_receive(:tag_name).and_return('input')
+    expect(page_object).not_to receive(:select_rb)
+    expect(page_object).to receive(:rb_element).twice.and_return(browser)
+    expect(browser).to receive(:enabled?).and_return(true)
+    expect(browser).to receive(:visible?).and_return(false)
+    expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('rb' => true)
   end
 end

--- a/spec/page-object/platforms/selenium_webdriver/selenium_page_object_spec.rb
+++ b/spec/page-object/platforms/selenium_webdriver/selenium_page_object_spec.rb
@@ -43,19 +43,19 @@ describe PageObject::Platforms::SeleniumWebDriver::PageObject do
       selenium_browser.should_receive(:find_element).and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
       element = page.link_element(:text => 'blah')
-      element.element.should be_instance_of PageObject::Platforms::SeleniumWebDriver::SurrogateSeleniumElement
+      expect(element.element).to be_instance_of PageObject::Platforms::SeleniumWebDriver::SurrogateSeleniumElement
     end
 
     it "should know it is not exist" do
       selenium_browser.should_receive(:find_element).twice.and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
-      page.link_element(:text => 'blah').element.exists?.should be false
+      expect(page.link_element(:text => 'blah').element.exists?).to be false
     end
 
     it "should know it is not visible" do
       selenium_browser.should_receive(:find_element).twice.and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
-      page.link_element(:text => 'blah').element.should_not be_visible
+      expect(page.link_element(:text => 'blah').element).not_to be_visible
     end
 
     it "should raise an error when actions are requested" do

--- a/spec/page-object/platforms/selenium_webdriver/selenium_page_object_spec.rb
+++ b/spec/page-object/platforms/selenium_webdriver/selenium_page_object_spec.rb
@@ -11,55 +11,55 @@ describe PageObject::Platforms::SeleniumWebDriver::PageObject do
   let(:selenium_page_object) { SeleniumTestPageObject.new(selenium_browser) }
   
   before(:each) do
-    selenium_browser.stub(:switch_to).and_return(selenium_browser)
-    selenium_browser.stub(:default_content)
+    allow(selenium_browser).to receive(:switch_to).and_return(selenium_browser)
+    allow(selenium_browser).to receive(:default_content)
   end
 
   context "when building identifiers hash" do
     it "should add tag_name when identifying by text for hidden_field" do
       expected_identifier = {:text => 'foo', :tag_name => 'input', :type => 'hidden'}
-      PageObject::Elements::HiddenField.should_receive(:selenium_identifier_for).with(expected_identifier)
-      selenium_browser.should_receive(:find_element)
+      expect(PageObject::Elements::HiddenField).to receive(:selenium_identifier_for).with(expected_identifier)
+      expect(selenium_browser).to receive(:find_element)
       selenium_page_object.platform.hidden_field_for(:text => 'foo')
     end
 
     it "should add tag_name when identifying by href for anchor" do
       expected_identifier = {:href => 'foo', :tag_name => 'a'}
-      PageObject::Elements::Link.should_receive(:selenium_identifier_for).with(expected_identifier)
-      selenium_browser.should_receive(:find_element)
+      expect(PageObject::Elements::Link).to receive(:selenium_identifier_for).with(expected_identifier)
+      expect(selenium_browser).to receive(:find_element)
       selenium_page_object.platform.link_for(:href => 'foo')
     end
     
     it "should add tag_name when identifying by text for div" do
       expected_identifier = {:text => 'foo', :tag_name => 'div'}
-      PageObject::Elements::Div.should_receive(:selenium_identifier_for).with(expected_identifier)
-      selenium_browser.should_receive(:find_element)
+      expect(PageObject::Elements::Div).to receive(:selenium_identifier_for).with(expected_identifier)
+      expect(selenium_browser).to receive(:find_element)
       selenium_page_object.platform.div_for(:text => 'foo')
     end
   end
 
   context "when trying to find an element that does not exist" do
     it "should return a surogate selenium object" do
-      selenium_browser.should_receive(:find_element).and_raise(Selenium::WebDriver::Error::NoSuchElementError)
+      expect(selenium_browser).to receive(:find_element).and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
       element = page.link_element(:text => 'blah')
       expect(element.element).to be_instance_of PageObject::Platforms::SeleniumWebDriver::SurrogateSeleniumElement
     end
 
     it "should know it is not exist" do
-      selenium_browser.should_receive(:find_element).twice.and_raise(Selenium::WebDriver::Error::NoSuchElementError)
+      expect(selenium_browser).to receive(:find_element).twice.and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
       expect(page.link_element(:text => 'blah').element.exists?).to be false
     end
 
     it "should know it is not visible" do
-      selenium_browser.should_receive(:find_element).twice.and_raise(Selenium::WebDriver::Error::NoSuchElementError)
+      expect(selenium_browser).to receive(:find_element).twice.and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
       expect(page.link_element(:text => 'blah').element).not_to be_visible
     end
 
     it "should raise an error when actions are requested" do
-      selenium_browser.should_receive(:find_element).and_raise(Selenium::WebDriver::Error::NoSuchElementError)
+      expect(selenium_browser).to receive(:find_element).and_raise(Selenium::WebDriver::Error::NoSuchElementError)
       page = SeleniumTestPageObject.new(selenium_browser)
       element = page.link_element(:text => 'blah')
       expect { element.text }.to raise_error

--- a/spec/page-object/platforms/selenium_webdriver_spec.rb
+++ b/spec/page-object/platforms/selenium_webdriver_spec.rb
@@ -4,26 +4,26 @@ require 'spec_helper'
 describe PageObject::Platforms::SeleniumWebDriver do
 
   it "should be registered as an adapter" do
-    PageObject::Platforms.get[:selenium_webdriver].should be PageObject::Platforms::SeleniumWebDriver
-
+    expect(PageObject::Platforms.get[:selenium_webdriver]).to be PageObject::Platforms::SeleniumWebDriver
   end
+  
   describe 'create page object' do
     let(:browser) { double('browser') }
     let(:subject) { PageObject::Platforms::SeleniumWebDriver.create_page_object(browser) }
     
     it "should create a SeleniumPageObject" do
-      subject.should be_kind_of PageObject::Platforms::SeleniumWebDriver::PageObject
+      expect(subject).to be_kind_of PageObject::Platforms::SeleniumWebDriver::PageObject
     end
   end
   
   describe "is for?" do
     it "should be true when the browser is a selenium driver" do
       browser = mock_selenium_browser()
-      PageObject::Platforms::SeleniumWebDriver.is_for?(browser).should == true
+      expect(PageObject::Platforms::SeleniumWebDriver.is_for?(browser)).to eql true
     end
     
     it "should be false when the browser is anything else" do
-      PageObject::Platforms::SeleniumWebDriver.is_for?("asdf").should == false
+      expect(PageObject::Platforms::SeleniumWebDriver.is_for?("asdf")).to eql false
     end
   end
 end

--- a/spec/page-object/platforms/watir_webdriver/watir_page_object_spec.rb
+++ b/spec/page-object/platforms/watir_webdriver/watir_page_object_spec.rb
@@ -6,23 +6,23 @@ describe PageObject::Platforms::WatirWebDriver do
     let(:subject) { PageObject::Platforms::WatirWebDriver.create_page_object(browser) }
     
     it "should create a WatirPageObject" do
-      subject.should be_kind_of PageObject::Platforms::WatirWebDriver::PageObject
+      expect(subject).to be_kind_of PageObject::Platforms::WatirWebDriver::PageObject
     end
     
     it "should give the watir page object the browser" do
-      subject.browser.should be browser
+      expect(subject.browser).to be browser
     end
   end
   
   describe "is for?" do
     it "should be true when the browser is Watir::Browser" do
       browser = mock_watir_browser()
-      PageObject::Platforms::WatirWebDriver.is_for?(browser).should be true
+      expect(PageObject::Platforms::WatirWebDriver.is_for?(browser)).to be true
     end
     
     it "should be false at any other point" do
       browser = 'asdf'
-      PageObject::Platforms::WatirWebDriver.is_for?('asdf').should be false
+      expect(PageObject::Platforms::WatirWebDriver.is_for?('asdf')).to be false
     end
   end
 end

--- a/spec/page-object/platforms/watir_webdriver_spec.rb
+++ b/spec/page-object/platforms/watir_webdriver_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PageObject::Platforms::WatirWebDriver do
   
   it "should be in the PageObjects Adapters list" do
-    PageObject::Platforms.get[:watir_webdriver].should be PageObject::Platforms::WatirWebDriver
+    expect(PageObject::Platforms.get[:watir_webdriver]).to be PageObject::Platforms::WatirWebDriver
   end
   
 end

--- a/spec/page-object/selenium_accessors_spec.rb
+++ b/spec/page-object/selenium_accessors_spec.rb
@@ -155,7 +155,7 @@ describe PageObject::Accessors do
     it "should return a link element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.google_search_element
-      element.should be_instance_of PageObject::Elements::Link
+      expect(element).to be_instance_of PageObject::Elements::Link
     end
   end
 
@@ -164,7 +164,7 @@ describe PageObject::Accessors do
     it "should get the text from the text field element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:attribute).with('value').and_return('Katie')
-      selenium_page_object.first_name.should == 'Katie'
+      expect(selenium_page_object.first_name).to eql 'Katie'
     end
 
     it "should set some text on a text field element" do
@@ -177,7 +177,7 @@ describe PageObject::Accessors do
     it "should retrieve a text field element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.first_name_element
-      element.should be_instance_of PageObject::Elements::TextField
+      expect(element).to be_instance_of PageObject::Elements::TextField
     end
   end
 
@@ -186,13 +186,13 @@ describe PageObject::Accessors do
     it "should get the text from a hidden field" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:attribute).with('value').and_return("12345")
-      selenium_page_object.social_security_number.should == "12345"
+      expect(selenium_page_object.social_security_number).to eql "12345"
     end
 
     it "should retrieve a hidden field element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.social_security_number_element
-      element.should be_instance_of PageObject::Elements::HiddenField
+      expect(element).to be_instance_of PageObject::Elements::HiddenField
     end
   end
 
@@ -207,13 +207,13 @@ describe PageObject::Accessors do
     it "should get the text from the text area" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:attribute).with('value').and_return("123 main street")
-      selenium_page_object.address.should == "123 main street"
+      expect(selenium_page_object.address).to eql "123 main street"
     end
 
     it "should retrieve a text area element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.address_element
-      element.should be_instance_of PageObject::Elements::TextArea
+      expect(element).to be_instance_of PageObject::Elements::TextArea
     end
   end
 
@@ -224,7 +224,7 @@ describe PageObject::Accessors do
       selected.should_receive(:text).and_return("OH")
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:find_elements).and_return([selected])
-      selenium_page_object.state.should == "OH"
+      expect(selenium_page_object.state).to eql "OH"
     end
 
     it "should set the current item of a select list" do
@@ -239,7 +239,7 @@ describe PageObject::Accessors do
     it "should retrieve the select list element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.state_element
-      element.should be_instance_of PageObject::Elements::SelectList
+      expect(element).to be_instance_of PageObject::Elements::SelectList
     end
     
     it "should return list of selection options" do
@@ -252,7 +252,7 @@ describe PageObject::Accessors do
       select_element.should_receive(:options).twice.and_return([option1, option2])
       selenium_page_object.should_receive(:state_element).and_return(select_element)
       
-      selenium_page_object.state_options.should == ["CA","OH"]
+      expect(selenium_page_object.state_options).to eql ["CA","OH"]
     end
     
   end
@@ -276,13 +276,13 @@ describe PageObject::Accessors do
     it "should know if a check box element is selected" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:selected?).and_return(true)
-      selenium_page_object.active_checked?.should be true
+      expect(selenium_page_object.active_checked?).to be true
     end
 
     it "should retrieve a checkbox element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.active_element
-      element.should be_instance_of PageObject::Elements::CheckBox
+      expect(element).to be_instance_of PageObject::Elements::CheckBox
     end
   end
 
@@ -304,7 +304,7 @@ describe PageObject::Accessors do
     it "should retrieve a radio button element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.first_element
-      element.should be_instance_of PageObject::Elements::RadioButton
+      expect(element).to be_instance_of PageObject::Elements::RadioButton
     end
   end
 
@@ -318,7 +318,7 @@ describe PageObject::Accessors do
     it "should retrieve a button element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.click_me_element
-      element.should be_instance_of PageObject::Elements::Button
+      expect(element).to be_instance_of PageObject::Elements::Button
     end
   end
 
@@ -326,13 +326,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from a div" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("Message from div")
-      selenium_page_object.message.should == "Message from div"
+      expect(selenium_page_object.message).to eql "Message from div"
     end
 
     it "should retrieve the div element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.message_element
-      element.should be_instance_of PageObject::Elements::Div
+      expect(element).to be_instance_of PageObject::Elements::Div
     end
   end
 
@@ -340,13 +340,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from a span" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("Alert")
-      selenium_page_object.alert_span.should == "Alert"
+      expect(selenium_page_object.alert_span).to eql "Alert"
     end
 
     it "should retrieve the span element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.alert_span_element
-      element.should be_instance_of PageObject::Elements::Span
+      expect(element).to be_instance_of PageObject::Elements::Span
     end
   end
 
@@ -354,7 +354,7 @@ describe PageObject::Accessors do
     it "should retrieve the table element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.cart_element
-      element.should be_instance_of(PageObject::Elements::Table)
+      expect(element).to be_instance_of(PageObject::Elements::Table)
     end
   end
 
@@ -362,13 +362,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the cell" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return('celldata')
-      selenium_page_object.total.should == 'celldata'
+      expect(selenium_page_object.total).to eql 'celldata'
     end
 
     it "should retrieve the cell element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.total_element
-      element.should be_instance_of PageObject::Elements::TableCell
+      expect(element).to be_instance_of PageObject::Elements::TableCell
     end
   end
 
@@ -376,7 +376,7 @@ describe PageObject::Accessors do
     it "should retrieve the image element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.logo_element
-      element.should be_instance_of PageObject::Elements::Image
+      expect(element).to be_instance_of PageObject::Elements::Image
     end
   end
 
@@ -384,7 +384,7 @@ describe PageObject::Accessors do
     it "should retrieve the form element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.login_element
-      element.should be_instance_of PageObject::Elements::Form
+      expect(element).to be_instance_of PageObject::Elements::Form
     end
   end
 
@@ -392,13 +392,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the list item" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.item_one.should == "value"
+      expect(selenium_page_object.item_one).to eql "value"
     end
 
     it "should retrieve the list item from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.item_one_element
-      element.should be_instance_of PageObject::Elements::ListItem
+      expect(element).to be_instance_of PageObject::Elements::ListItem
     end
   end
 
@@ -406,7 +406,7 @@ describe PageObject::Accessors do
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.menu_element
-      element.should be_instance_of PageObject::Elements::UnorderedList
+      expect(element).to be_instance_of PageObject::Elements::UnorderedList
     end
   end
 
@@ -414,7 +414,7 @@ describe PageObject::Accessors do
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.top_five_element
-      element.should be_instance_of PageObject::Elements::OrderedList
+      expect(element).to be_instance_of PageObject::Elements::OrderedList
     end
   end
   
@@ -422,13 +422,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the h1" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.heading1.should == "value"
+      expect(selenium_page_object.heading1).to eql "value"
     end
   
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading1_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
   
@@ -436,13 +436,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the h2" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.heading2.should == "value"
+      expect(selenium_page_object.heading2).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading2_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
@@ -450,13 +450,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the h3" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.heading3.should == "value"
+      expect(selenium_page_object.heading3).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading3_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
@@ -464,13 +464,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the h4" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.heading4.should == "value"
+      expect(selenium_page_object.heading4).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading4_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
@@ -478,13 +478,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the h5" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.heading5.should == "value"
+      expect(selenium_page_object.heading5).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading5_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
@@ -492,13 +492,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the h6" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.heading6.should == "value"
+      expect(selenium_page_object.heading6).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading6_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
@@ -507,13 +507,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the p" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.first_para.should == "value"
+      expect(selenium_page_object.first_para).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.first_para_element
-      element.should be_instance_of PageObject::Elements::Paragraph
+      expect(element).to be_instance_of PageObject::Elements::Paragraph
     end
   end
 
@@ -527,19 +527,19 @@ describe PageObject::Accessors do
     it "should retrieve a file_field element" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.upload_me_element
-      element.should be_instance_of PageObject::Elements::FileField
+      expect(element).to be_instance_of PageObject::Elements::FileField
     end
   end
 
   describe "area accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        selenium_page_object.should respond_to(:img_area)
-        selenium_page_object.should respond_to(:img_area_element)
+        expect(selenium_page_object).to respond_to(:img_area)
+        expect(selenium_page_object).to respond_to(:img_area_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.img_area_element.should == "area"
+        expect(block_page_object.img_area_element).to eql "area"
       end
     end
 
@@ -552,18 +552,18 @@ describe PageObject::Accessors do
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.img_area_element
-      element.should be_instance_of PageObject::Elements::Area
+      expect(element).to be_instance_of PageObject::Elements::Area
     end
   end
 
   describe "canvas accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        selenium_page_object.should respond_to(:my_canvas_element)
+        expect(selenium_page_object).to respond_to(:my_canvas_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.my_canvas_element.should == "canvas"
+        expect(block_page_object.my_canvas_element).to eql "canvas"
       end
     end
   end
@@ -571,11 +571,11 @@ describe PageObject::Accessors do
   describe "audio accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        selenium_page_object.should respond_to(:acdc_element)
+        expect(selenium_page_object).to respond_to(:acdc_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.acdc_element.should == "audio"
+        expect(block_page_object.acdc_element).to eql "audio"
       end
     end
   end
@@ -583,11 +583,11 @@ describe PageObject::Accessors do
   describe "video accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        selenium_page_object.should respond_to(:movie_element)
+        expect(selenium_page_object).to respond_to(:movie_element)
       end
 
       it "should call a block on the elmenet method when present" do
-        block_page_object.movie_element.should == "video"
+        expect(block_page_object.movie_element).to eql "video"
       end
     end
   end
@@ -596,13 +596,13 @@ describe PageObject::Accessors do
     it "should retrieve the text from the b" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       selenium_browser.should_receive(:text).and_return("value")
-      selenium_page_object.bold.should == "value"
+      expect(selenium_page_object.bold).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       selenium_browser.should_receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.bold_element
-      element.should be_instance_of PageObject::Elements::Bold
+      expect(element).to be_instance_of PageObject::Elements::Bold
     end
   end
 

--- a/spec/page-object/selenium_accessors_spec.rb
+++ b/spec/page-object/selenium_accessors_spec.rb
@@ -142,18 +142,18 @@ describe PageObject::Accessors do
   let(:block_page_object) { SeleniumBlockPageObject.new(selenium_browser) }
   
   before(:each) do
-    selenium_browser.stub(:switch_to).and_return(selenium_browser)
-    selenium_browser.stub(:default_content)
+    allow(selenium_browser).to receive(:switch_to).and_return(selenium_browser)
+    allow(selenium_browser).to receive(:default_content)
   end
 
   describe "link accessors" do
     it "should select a link" do
-      selenium_browser.stub_chain(:find_element, :click)
+      allow(selenium_browser).to receive_messages(find_element: selenium_browser, click: selenium_browser)
       selenium_page_object.google_search
     end
 
     it "should return a link element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.google_search_element
       expect(element).to be_instance_of PageObject::Elements::Link
     end
@@ -162,20 +162,20 @@ describe PageObject::Accessors do
 
   describe "text_field accessors" do
     it "should get the text from the text field element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:attribute).with('value').and_return('Katie')
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:attribute).with('value').and_return('Katie')
       expect(selenium_page_object.first_name).to eql 'Katie'
     end
 
     it "should set some text on a text field element" do
-      selenium_browser.should_receive(:find_element).twice.and_return(selenium_browser)
-      selenium_browser.should_receive(:clear)
-      selenium_browser.should_receive(:send_keys).with('Katie')
+      expect(selenium_browser).to receive(:find_element).twice.and_return(selenium_browser)
+      expect(selenium_browser).to receive(:clear)
+      expect(selenium_browser).to receive(:send_keys).with('Katie')
       selenium_page_object.first_name = 'Katie'
     end
 
     it "should retrieve a text field element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.first_name_element
       expect(element).to be_instance_of PageObject::Elements::TextField
     end
@@ -184,13 +184,13 @@ describe PageObject::Accessors do
 
   describe "hidden field accessors" do
     it "should get the text from a hidden field" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:attribute).with('value').and_return("12345")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:attribute).with('value').and_return("12345")
       expect(selenium_page_object.social_security_number).to eql "12345"
     end
 
     it "should retrieve a hidden field element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.social_security_number_element
       expect(element).to be_instance_of PageObject::Elements::HiddenField
     end
@@ -198,20 +198,20 @@ describe PageObject::Accessors do
 
   describe "text area accessors" do
     it "should set some text on the text area" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:clear)
-      selenium_browser.should_receive(:send_keys).with("123 main street")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:clear)
+      expect(selenium_browser).to receive(:send_keys).with("123 main street")
       selenium_page_object.address = "123 main street"
     end
 
     it "should get the text from the text area" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:attribute).with('value').and_return("123 main street")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:attribute).with('value').and_return("123 main street")
       expect(selenium_page_object.address).to eql "123 main street"
     end
 
     it "should retrieve a text area element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.address_element
       expect(element).to be_instance_of PageObject::Elements::TextArea
     end
@@ -220,24 +220,24 @@ describe PageObject::Accessors do
   describe "select_list accessors" do
     it "should should get the current item from a select list" do
       selected = "OH"
-      selected.should_receive(:selected?).and_return(selected)
-      selected.should_receive(:text).and_return("OH")
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:find_elements).and_return([selected])
+      expect(selected).to receive(:selected?).and_return(selected)
+      expect(selected).to receive(:text).and_return("OH")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_elements).and_return([selected])
       expect(selenium_page_object.state).to eql "OH"
     end
 
     it "should set the current item of a select list" do
       option = double('option')
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:find_elements).and_return([option])
-      option.should_receive(:text).and_return('OH')
-      option.should_receive(:click)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_elements).and_return([option])
+      expect(option).to receive(:text).and_return('OH')
+      expect(option).to receive(:click)
       selenium_page_object.state = "OH"
     end
 
     it "should retrieve the select list element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.state_element
       expect(element).to be_instance_of PageObject::Elements::SelectList
     end
@@ -245,12 +245,12 @@ describe PageObject::Accessors do
     it "should return list of selection options" do
       option1 = double('option')
       option2 = double('option')
-      option1.should_receive(:text).and_return("CA")
-      option2.should_receive(:text).and_return("OH")
+      expect(option1).to receive(:text).and_return("CA")
+      expect(option2).to receive(:text).and_return("OH")
 
       select_element = double("select")
-      select_element.should_receive(:options).twice.and_return([option1, option2])
-      selenium_page_object.should_receive(:state_element).and_return(select_element)
+      expect(select_element).to receive(:options).twice.and_return([option1, option2])
+      expect(selenium_page_object).to receive(:state_element).and_return(select_element)
       
       expect(selenium_page_object.state_options).to eql ["CA","OH"]
     end
@@ -260,27 +260,27 @@ describe PageObject::Accessors do
 
   describe "check_box accessors" do
     it "should check a check box element" do
-      selenium_browser.should_receive(:find_element).twice.and_return(selenium_browser)
-      selenium_browser.should_receive(:selected?).and_return(false)
-      selenium_browser.should_receive(:click)
+      expect(selenium_browser).to receive(:find_element).twice.and_return(selenium_browser)
+      expect(selenium_browser).to receive(:selected?).and_return(false)
+      expect(selenium_browser).to receive(:click)
       selenium_page_object.check_active
     end
 
     it "should clear a check box element" do
-      selenium_browser.should_receive(:find_element).twice.and_return(selenium_browser)
-      selenium_browser.should_receive(:selected?).and_return(true)
-      selenium_browser.should_receive(:click)
+      expect(selenium_browser).to receive(:find_element).twice.and_return(selenium_browser)
+      expect(selenium_browser).to receive(:selected?).and_return(true)
+      expect(selenium_browser).to receive(:click)
       selenium_page_object.uncheck_active
     end
 
     it "should know if a check box element is selected" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:selected?).and_return(true)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:selected?).and_return(true)
       expect(selenium_page_object.active_checked?).to be true
     end
 
     it "should retrieve a checkbox element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.active_element
       expect(element).to be_instance_of PageObject::Elements::CheckBox
     end
@@ -289,20 +289,20 @@ describe PageObject::Accessors do
 
   describe "radio accessors" do
     it "should select a radio button" do
-      selenium_browser.should_receive(:find_element).twice.and_return(selenium_browser)
-      selenium_browser.should_receive(:selected?).and_return(false)
-      selenium_browser.should_receive(:click)
+      expect(selenium_browser).to receive(:find_element).twice.and_return(selenium_browser)
+      expect(selenium_browser).to receive(:selected?).and_return(false)
+      expect(selenium_browser).to receive(:click)
       selenium_page_object.select_first
     end
 
     it "should determine if a radio is selected" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:selected?).and_return(true)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:selected?).and_return(true)
       selenium_page_object.first_selected?
     end
 
     it "should retrieve a radio button element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.first_element
       expect(element).to be_instance_of PageObject::Elements::RadioButton
     end
@@ -310,13 +310,13 @@ describe PageObject::Accessors do
 
   describe "button accessors" do
     it "should be able to click a button" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:click)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:click)
       selenium_page_object.click_me
     end
 
     it "should retrieve a button element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.click_me_element
       expect(element).to be_instance_of PageObject::Elements::Button
     end
@@ -324,13 +324,13 @@ describe PageObject::Accessors do
 
   describe "div accessors" do
     it "should retrieve the text from a div" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("Message from div")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("Message from div")
       expect(selenium_page_object.message).to eql "Message from div"
     end
 
     it "should retrieve the div element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.message_element
       expect(element).to be_instance_of PageObject::Elements::Div
     end
@@ -338,13 +338,13 @@ describe PageObject::Accessors do
 
   describe "span accessors" do
     it "should retrieve the text from a span" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("Alert")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("Alert")
       expect(selenium_page_object.alert_span).to eql "Alert"
     end
 
     it "should retrieve the span element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.alert_span_element
       expect(element).to be_instance_of PageObject::Elements::Span
     end
@@ -352,7 +352,7 @@ describe PageObject::Accessors do
 
   describe "table accessors" do
     it "should retrieve the table element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.cart_element
       expect(element).to be_instance_of(PageObject::Elements::Table)
     end
@@ -360,13 +360,13 @@ describe PageObject::Accessors do
 
   describe "table cell accessors" do
     it "should retrieve the text from the cell" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return('celldata')
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return('celldata')
       expect(selenium_page_object.total).to eql 'celldata'
     end
 
     it "should retrieve the cell element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.total_element
       expect(element).to be_instance_of PageObject::Elements::TableCell
     end
@@ -374,7 +374,7 @@ describe PageObject::Accessors do
 
   describe "image accessors" do
     it "should retrieve the image element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.logo_element
       expect(element).to be_instance_of PageObject::Elements::Image
     end
@@ -382,7 +382,7 @@ describe PageObject::Accessors do
 
   describe "form accessors" do
     it "should retrieve the form element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.login_element
       expect(element).to be_instance_of PageObject::Elements::Form
     end
@@ -390,13 +390,13 @@ describe PageObject::Accessors do
 
   describe "list item accessors" do
     it "should retrieve the text from the list item" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.item_one).to eql "value"
     end
 
     it "should retrieve the list item from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.item_one_element
       expect(element).to be_instance_of PageObject::Elements::ListItem
     end
@@ -404,7 +404,7 @@ describe PageObject::Accessors do
 
   describe "unordered list accessors" do
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.menu_element
       expect(element).to be_instance_of PageObject::Elements::UnorderedList
     end
@@ -412,7 +412,7 @@ describe PageObject::Accessors do
 
   describe "ordered list accessors" do
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.top_five_element
       expect(element).to be_instance_of PageObject::Elements::OrderedList
     end
@@ -420,13 +420,13 @@ describe PageObject::Accessors do
   
   describe "h1 accessors" do
     it "should retrieve the text from the h1" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.heading1).to eql "value"
     end
   
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading1_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -434,13 +434,13 @@ describe PageObject::Accessors do
   
   describe "h2 accessors" do
     it "should retrieve the text from the h2" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.heading2).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading2_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -448,13 +448,13 @@ describe PageObject::Accessors do
 
   describe "h3 accessors" do
     it "should retrieve the text from the h3" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.heading3).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading3_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -462,13 +462,13 @@ describe PageObject::Accessors do
 
   describe "h4 accessors" do
     it "should retrieve the text from the h4" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.heading4).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading4_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -476,13 +476,13 @@ describe PageObject::Accessors do
 
   describe "h5 accessors" do
     it "should retrieve the text from the h5" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.heading5).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading5_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -490,13 +490,13 @@ describe PageObject::Accessors do
 
   describe "h6 accessors" do
     it "should retrieve the text from the h6" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.heading6).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.heading6_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -505,13 +505,13 @@ describe PageObject::Accessors do
 
   describe "p accessors" do
     it "should retrieve the text from the p" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.first_para).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.first_para_element
       expect(element).to be_instance_of PageObject::Elements::Paragraph
     end
@@ -519,13 +519,13 @@ describe PageObject::Accessors do
 
   describe "file_field accessors" do
     it "should set the file name" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:send_keys).with('some_file')
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:send_keys).with('some_file')
       selenium_page_object.upload_me = 'some_file'
     end
 
     it "should retrieve a file_field element" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.upload_me_element
       expect(element).to be_instance_of PageObject::Elements::FileField
     end
@@ -544,13 +544,13 @@ describe PageObject::Accessors do
     end
 
     it "should click on the area" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:click)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:click)
       selenium_page_object.img_area
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.img_area_element
       expect(element).to be_instance_of PageObject::Elements::Area
     end
@@ -594,13 +594,13 @@ describe PageObject::Accessors do
 
   describe "b accessors" do
     it "should retrieve the text from the b" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
-      selenium_browser.should_receive(:text).and_return("value")
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:text).and_return("value")
       expect(selenium_page_object.bold).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      selenium_browser.should_receive(:find_element).and_return(selenium_browser)
+      expect(selenium_browser).to receive(:find_element).and_return(selenium_browser)
       element = selenium_page_object.bold_element
       expect(element).to be_instance_of PageObject::Elements::Bold
     end

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -176,14 +176,14 @@ describe PageObject::Accessors do
     end
 
     it "should provide the page url" do
-      watir_page_object.page_url_value.should == 'http://apple.com'
+      expect(watir_page_object.page_url_value).to eql 'http://apple.com'
     end
   end
 
   context "validating the page title" do
     it "should validate the title" do
       watir_browser.should_receive(:title).and_return("Expected Title")
-      watir_page_object.should have_expected_title
+      expect(watir_page_object).to have_expected_title
     end
 
     it "should validate the by regexp" do
@@ -192,7 +192,7 @@ describe PageObject::Accessors do
         expected_title /\w+ \w+/
       end
       watir_browser.should_receive(:title).and_return("Expected Title")
-      RegexpExpectedTitle.new(watir_browser).should have_expected_title
+      expect(RegexpExpectedTitle.new(watir_browser)).to have_expected_title
     end
 
     it "should raise error when it does not have expected title" do
@@ -213,7 +213,7 @@ describe PageObject::Accessors do
         include PageObject
         expected_element :foo
       end
-      FakePage.new(watir_browser).should_not have_expected_element
+      expect(FakePage.new(watir_browser)).not_to have_expected_element
     end
   end
 
@@ -307,7 +307,7 @@ describe PageObject::Accessors do
 
     it "should work for a table" do
       mock_driver_for :table
-      default_identifier.default_tab_element.should_not be_nil
+      expect(default_identifier.default_tab_element).not_to be_nil
     end
 
     it "should work for a cell" do
@@ -395,12 +395,12 @@ describe PageObject::Accessors do
   context "link accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:google_search)
-        watir_page_object.should respond_to(:google_search_element)
+        expect(watir_page_object).to respond_to(:google_search)
+        expect(watir_page_object).to respond_to(:google_search_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.continue_element.should == "link"
+        expect(block_page_object.continue_element).to eql "link"
       end
     end
 
@@ -412,7 +412,7 @@ describe PageObject::Accessors do
     it "should return a link element" do
       watir_browser.should_receive(:link).and_return(watir_browser)
       element = watir_page_object.google_search_element
-      element.should be_instance_of PageObject::Elements::Link
+      expect(element).to be_instance_of PageObject::Elements::Link
     end
   end
 
@@ -420,21 +420,21 @@ describe PageObject::Accessors do
   describe "text_field accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:first_name)
-        watir_page_object.should respond_to(:first_name=)
-        watir_page_object.should respond_to(:first_name_element)
-        watir_page_object.should respond_to(:first_name?)
+        expect(watir_page_object).to respond_to(:first_name)
+        expect(watir_page_object).to respond_to(:first_name=)
+        expect(watir_page_object).to respond_to(:first_name_element)
+        expect(watir_page_object).to respond_to(:first_name?)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.first_name_element.should == "text_field"
+        expect(block_page_object.first_name_element).to eql "text_field"
       end
     end
 
     it "should get the text from the text field element" do
       watir_browser.should_receive(:text_field).and_return(watir_browser)
       watir_browser.should_receive(:value).and_return('Kim')
-      watir_page_object.first_name.should == 'Kim'
+      expect(watir_page_object.first_name).to eql 'Kim'
     end
 
     it "should set some text on a text field element" do
@@ -446,7 +446,7 @@ describe PageObject::Accessors do
     it "should retrieve a text field element" do
       watir_browser.should_receive(:text_field).and_return(watir_browser)
       element = watir_page_object.first_name_element
-      element.should be_instance_of PageObject::Elements::TextField
+      expect(element).to be_instance_of PageObject::Elements::TextField
     end
   end
 
@@ -454,38 +454,38 @@ describe PageObject::Accessors do
   describe "hidden field accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:social_security_number)
-        watir_page_object.should respond_to(:social_security_number_element)
+        expect(watir_page_object).to respond_to(:social_security_number)
+        expect(watir_page_object).to respond_to(:social_security_number_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.secret_element.should == "hidden_field"
+        expect(block_page_object.secret_element).to eql "hidden_field"
       end
     end
 
     it "should get the text from a hidden field" do
       watir_browser.should_receive(:hidden).and_return(watir_browser)
       watir_browser.should_receive(:value).and_return("value")
-      watir_page_object.social_security_number.should == "value"
+      expect(watir_page_object.social_security_number).to eql "value"
     end
 
     it "should retrieve a hidden field element" do
       watir_browser.should_receive(:hidden).and_return(watir_browser)
       element = watir_page_object.social_security_number_element
-      element.should be_instance_of(PageObject::Elements::HiddenField)
+      expect(element).to be_instance_of(PageObject::Elements::HiddenField)
     end
   end
 
   describe "text area accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:address)
-        watir_page_object.should respond_to(:address=)
-        watir_page_object.should respond_to(:address_element)
+        expect(watir_page_object).to respond_to(:address)
+        expect(watir_page_object).to respond_to(:address=)
+        expect(watir_page_object).to respond_to(:address_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.address_element.should == "text_area"
+        expect(block_page_object.address_element).to eql "text_area"
       end
     end
 

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -143,7 +143,7 @@ describe PageObject::Accessors do
   context "goto a page" do
 
     it "should navigate to a page when requested" do
-      watir_browser.should_receive(:goto)
+      expect(watir_browser).to receive(:goto)
       WatirAccessorsTestPageObject.new(watir_browser, true)
     end
 
@@ -158,20 +158,20 @@ describe PageObject::Accessors do
           super(b, v)
         end
       end
-      watir_browser.should_receive(:goto).with('custom')
+      expect(watir_browser).to receive(:goto).with('custom')
       SymbolPageUrl.new(watir_browser, true, 'custom')
 
-      watir_browser.should_receive(:goto).with('different')
+      expect(watir_browser).to receive(:goto).with('different')
       SymbolPageUrl.new(watir_browser, true, 'different')
     end
 
     it "should not navigate to a page when not requested" do
-      watir_browser.should_not_receive(:goto)
+      expect(watir_browser).not_to receive(:goto)
       WatirAccessorsTestPageObject.new(watir_browser)
     end
 
     it "should not navigate to a page when 'page_url' not specified" do
-      watir_browser.should_not_receive(:goto)
+      expect(watir_browser).not_to receive(:goto)
       WatirBlockPageObject.new(watir_browser, true)
     end
 
@@ -182,7 +182,7 @@ describe PageObject::Accessors do
 
   context "validating the page title" do
     it "should validate the title" do
-      watir_browser.should_receive(:title).and_return("Expected Title")
+      expect(watir_browser).to receive(:title).and_return("Expected Title")
       expect(watir_page_object).to have_expected_title
     end
 
@@ -191,20 +191,20 @@ describe PageObject::Accessors do
         include PageObject
         expected_title /\w+ \w+/
       end
-      watir_browser.should_receive(:title).and_return("Expected Title")
+      expect(watir_browser).to receive(:title).and_return("Expected Title")
       expect(RegexpExpectedTitle.new(watir_browser)).to have_expected_title
     end
 
     it "should raise error when it does not have expected title" do
-      watir_browser.should_receive(:title).once.and_return("Not Expected")
+      expect(watir_browser).to receive(:title).once.and_return("Not Expected")
       expect { watir_page_object.has_expected_title? }.to raise_error
     end
   end
 
   context "validating the existence of an element" do
     it "should validate an element exists" do
-      watir_page_object.should_receive(:google_search_element).and_return(watir_browser)
-      watir_browser.should_receive(:when_present).and_return(true)
+      expect(watir_page_object).to receive(:google_search_element).and_return(watir_browser)
+      expect(watir_browser).to receive(:when_present).and_return(true)
       watir_page_object.has_expected_element?
     end
 
@@ -252,7 +252,7 @@ describe PageObject::Accessors do
     let(:default_identifier) { WatirDefaultIdentifier.new(watir_browser) }
 
     def mock_driver_for(tag)
-      watir_browser.should_receive(tag).with(:index => 0).and_return(watir_browser)
+      expect(watir_browser).to receive(tag).with(:index => 0).and_return(watir_browser)
     end
 
     it "should work with a text_field" do
@@ -405,12 +405,12 @@ describe PageObject::Accessors do
     end
 
     it "should select a link" do
-      watir_browser.stub_chain(:link, :click)
+      expect(watir_browser).to receive_messages(link: watir_browser, click: watir_browser)
       watir_page_object.google_search
     end
 
     it "should return a link element" do
-      watir_browser.should_receive(:link).and_return(watir_browser)
+      expect(watir_browser).to receive(:link).and_return(watir_browser)
       element = watir_page_object.google_search_element
       expect(element).to be_instance_of PageObject::Elements::Link
     end
@@ -432,19 +432,19 @@ describe PageObject::Accessors do
     end
 
     it "should get the text from the text field element" do
-      watir_browser.should_receive(:text_field).and_return(watir_browser)
-      watir_browser.should_receive(:value).and_return('Kim')
+      expect(watir_browser).to receive(:text_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:value).and_return('Kim')
       expect(watir_page_object.first_name).to eql 'Kim'
     end
 
     it "should set some text on a text field element" do
-      watir_browser.should_receive(:text_field).and_return(watir_browser)
-      watir_browser.should_receive(:set).with('Kim')
+      expect(watir_browser).to receive(:text_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:set).with('Kim')
       watir_page_object.first_name = 'Kim'
     end
 
     it "should retrieve a text field element" do
-      watir_browser.should_receive(:text_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:text_field).and_return(watir_browser)
       element = watir_page_object.first_name_element
       expect(element).to be_instance_of PageObject::Elements::TextField
     end
@@ -464,13 +464,13 @@ describe PageObject::Accessors do
     end
 
     it "should get the text from a hidden field" do
-      watir_browser.should_receive(:hidden).and_return(watir_browser)
-      watir_browser.should_receive(:value).and_return("value")
+      expect(watir_browser).to receive(:hidden).and_return(watir_browser)
+      expect(watir_browser).to receive(:value).and_return("value")
       expect(watir_page_object.social_security_number).to eql "value"
     end
 
     it "should retrieve a hidden field element" do
-      watir_browser.should_receive(:hidden).and_return(watir_browser)
+      expect(watir_browser).to receive(:hidden).and_return(watir_browser)
       element = watir_page_object.social_security_number_element
       expect(element).to be_instance_of(PageObject::Elements::HiddenField)
     end
@@ -490,19 +490,19 @@ describe PageObject::Accessors do
     end
 
     it "should set some text on the text area" do
-      watir_browser.should_receive(:textarea).and_return(watir_browser)
-      watir_browser.should_receive(:set).with("123 main street")
+      expect(watir_browser).to receive(:textarea).and_return(watir_browser)
+      expect(watir_browser).to receive(:set).with("123 main street")
       watir_page_object.address = "123 main street"
     end
 
     it "should get the text from the text area" do
-      watir_browser.should_receive(:textarea).and_return(watir_browser)
-      watir_browser.should_receive(:value).and_return("123 main street")
+      expect(watir_browser).to receive(:textarea).and_return(watir_browser)
+      expect(watir_browser).to receive(:value).and_return("123 main street")
       expect(watir_page_object.address).to eql "123 main street"
     end
 
     it "should retrieve a text area element" do
-      watir_browser.should_receive(:textarea).and_return(watir_browser)
+      expect(watir_browser).to receive(:textarea).and_return(watir_browser)
       element = watir_page_object.address_element
       expect(element).to be_instance_of PageObject::Elements::TextArea
     end
@@ -523,21 +523,21 @@ describe PageObject::Accessors do
 
     it "should get the current item from a select list" do
       selected = "OH"
-      selected.should_receive(:selected?).and_return(selected)
-      selected.should_receive(:text).and_return("OH")
-      watir_browser.should_receive(:select_list).and_return watir_browser
-      watir_browser.should_receive(:options).and_return([selected])
+      expect(selected).to receive(:selected?).and_return(selected)
+      expect(selected).to receive(:text).and_return("OH")
+      expect(watir_browser).to receive(:select_list).and_return watir_browser
+      expect(watir_browser).to receive(:options).and_return([selected])
       expect(watir_page_object.state).to eql "OH"
     end
 
     it "should set the current item of a select list" do
-      watir_browser.should_receive(:select_list).and_return watir_browser
-      watir_browser.should_receive(:select).with("OH")
+      expect(watir_browser).to receive(:select_list).and_return watir_browser
+      expect(watir_browser).to receive(:select).with("OH")
       watir_page_object.state = "OH"
     end
 
     it "should retreive the select list element" do
-      watir_browser.should_receive(:select_list).and_return(watir_browser)
+      expect(watir_browser).to receive(:select_list).and_return(watir_browser)
       element = watir_page_object.state_element
       expect(element).to be_instance_of PageObject::Elements::SelectList
     end
@@ -545,12 +545,12 @@ describe PageObject::Accessors do
     it "should return list of selection options" do
       option1 = double('option')
       option2 = double('option')
-      option1.should_receive(:text).and_return("CA")
-      option2.should_receive(:text).and_return("OH")
+      expect(option1).to receive(:text).and_return("CA")
+      expect(option2).to receive(:text).and_return("OH")
 
       select_element = double("select")
-      select_element.should_receive(:options).twice.and_return([option1, option2])
-      watir_page_object.should_receive(:state_element).and_return(select_element)
+      expect(select_element).to receive(:options).twice.and_return([option1, option2])
+      expect(watir_page_object).to receive(:state_element).and_return(select_element)
 
       expect(watir_page_object.state_options).to eql ["CA","OH"]
     end
@@ -571,25 +571,25 @@ describe PageObject::Accessors do
     end
 
     it "should check a check box element" do
-      watir_browser.should_receive(:checkbox).and_return(watir_browser)
-      watir_browser.should_receive(:set)
+      expect(watir_browser).to receive(:checkbox).and_return(watir_browser)
+      expect(watir_browser).to receive(:set)
       watir_page_object.check_active
     end
 
     it "should clear a check box element" do
-      watir_browser.should_receive(:checkbox).and_return(watir_browser)
-      watir_browser.should_receive(:clear)
+      expect(watir_browser).to receive(:checkbox).and_return(watir_browser)
+      expect(watir_browser).to receive(:clear)
       watir_page_object.uncheck_active
     end
 
     it "should know if a check box element is selected" do
-      watir_browser.should_receive(:checkbox).and_return(watir_browser)
-      watir_browser.should_receive(:set?).and_return(true)
+      expect(watir_browser).to receive(:checkbox).and_return(watir_browser)
+      expect(watir_browser).to receive(:set?).and_return(true)
       expect(watir_page_object.active_checked?).to be true
     end
 
     it "should retrieve a checkbox element" do
-      watir_browser.should_receive(:checkbox).and_return(watir_browser)
+      expect(watir_browser).to receive(:checkbox).and_return(watir_browser)
       element = watir_page_object.active_element
       expect(element).to be_instance_of PageObject::Elements::CheckBox
     end
@@ -610,19 +610,19 @@ describe PageObject::Accessors do
     end
 
     it "should select a radio button" do
-      watir_browser.should_receive(:radio).and_return(watir_browser)
-      watir_browser.should_receive(:set)
+      expect(watir_browser).to receive(:radio).and_return(watir_browser)
+      expect(watir_browser).to receive(:set)
       watir_page_object.select_first
     end
 
     it "should determine if a radio is selected" do
-      watir_browser.should_receive(:radio).and_return(watir_browser)
-      watir_browser.should_receive(:set?)
+      expect(watir_browser).to receive(:radio).and_return(watir_browser)
+      expect(watir_browser).to receive(:set?)
       watir_page_object.first_selected?
     end
 
     it "should retrieve a radio button element" do
-      watir_browser.should_receive(:radio).and_return(watir_browser)
+      expect(watir_browser).to receive(:radio).and_return(watir_browser)
       element = watir_page_object.first_element
       expect(element).to be_instance_of PageObject::Elements::RadioButton
     end
@@ -641,13 +641,13 @@ describe PageObject::Accessors do
     end
 
     it "should be able to click a button" do
-      watir_browser.should_receive(:button).and_return(watir_browser)
-      watir_browser.should_receive(:click)
+      expect(watir_browser).to receive(:button).and_return(watir_browser)
+      expect(watir_browser).to receive(:click)
       watir_page_object.click_me
     end
 
     it "should retrieve a button element" do
-      watir_browser.should_receive(:button).and_return(watir_browser)
+      expect(watir_browser).to receive(:button).and_return(watir_browser)
       element = watir_page_object.click_me_element
       expect(element).to be_instance_of PageObject::Elements::Button
     end
@@ -666,13 +666,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from a div" do
-      watir_browser.should_receive(:div).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("Message from div")
+      expect(watir_browser).to receive(:div).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("Message from div")
       expect(watir_page_object.message).to eql "Message from div"
     end
 
     it "should retrieve the div element from the page" do
-      watir_browser.should_receive(:div).and_return(watir_browser)
+      expect(watir_browser).to receive(:div).and_return(watir_browser)
       element = watir_page_object.message_element
       expect(element).to be_instance_of PageObject::Elements::Div
     end
@@ -691,13 +691,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from a span" do
-      watir_browser.should_receive(:span).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("Alert")
+      expect(watir_browser).to receive(:span).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("Alert")
       expect(watir_page_object.alert_span).to eql "Alert"
     end
 
     it "should retrieve the span element from the page" do
-      watir_browser.should_receive(:span).and_return(watir_browser)
+      expect(watir_browser).to receive(:span).and_return(watir_browser)
       element = watir_page_object.alert_span_element
       expect(element).to be_instance_of PageObject::Elements::Span
     end
@@ -716,7 +716,7 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the table element from the page" do
-      watir_browser.should_receive(:table).and_return(watir_browser)
+      expect(watir_browser).to receive(:table).and_return(watir_browser)
       element = watir_page_object.cart_element
       expect(element).to be_instance_of PageObject::Elements::Table
     end
@@ -735,13 +735,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text for the cell" do
-      watir_browser.should_receive(:td).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return('10.00')
+      expect(watir_browser).to receive(:td).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return('10.00')
       expect(watir_page_object.total).to eql '10.00'
     end
 
     it "should retrieve the cell element from the page" do
-      watir_browser.should_receive(:td).and_return(watir_browser)
+      expect(watir_browser).to receive(:td).and_return(watir_browser)
       element = watir_page_object.total_element
       expect(element).to be_instance_of PageObject::Elements::TableCell
     end
@@ -759,7 +759,7 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the image element from the page" do
-      watir_browser.should_receive(:image).and_return(watir_browser)
+      expect(watir_browser).to receive(:image).and_return(watir_browser)
       element = watir_page_object.logo_element
       expect(element).to be_instance_of PageObject::Elements::Image
     end
@@ -777,7 +777,7 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the form element from the page" do
-      watir_browser.should_receive(:form).and_return(watir_browser)
+      expect(watir_browser).to receive(:form).and_return(watir_browser)
       element = watir_page_object.login_element
       expect(element).to be_instance_of PageObject::Elements::Form
     end
@@ -796,13 +796,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the list item" do
-      watir_browser.should_receive(:li).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:li).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.item_one).to eql "value"
     end
 
     it "should retrieve the list item element from the page" do
-      watir_browser.should_receive(:li).and_return(watir_browser)
+      expect(watir_browser).to receive(:li).and_return(watir_browser)
       element = watir_page_object.item_one_element
       expect(element).to be_instance_of PageObject::Elements::ListItem
     end
@@ -820,7 +820,7 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:ul).and_return(watir_browser)
+      expect(watir_browser).to receive(:ul).and_return(watir_browser)
       element = watir_page_object.menu_element
       expect(element).to be_instance_of PageObject::Elements::UnorderedList
     end
@@ -838,7 +838,7 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:ol).and_return(watir_browser)
+      expect(watir_browser).to receive(:ol).and_return(watir_browser)
       element = watir_page_object.top_five_element
       expect(element).to be_instance_of PageObject::Elements::OrderedList
     end
@@ -857,13 +857,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the h1" do
-      watir_browser.should_receive(:h1).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:h1).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.heading1).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:h1).and_return(watir_browser)
+      expect(watir_browser).to receive(:h1).and_return(watir_browser)
       element = watir_page_object.heading1_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -882,13 +882,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the h2" do
-      watir_browser.should_receive(:h2).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:h2).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.heading2).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:h2).and_return(watir_browser)
+      expect(watir_browser).to receive(:h2).and_return(watir_browser)
       element = watir_page_object.heading2_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -907,13 +907,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the h3" do
-      watir_browser.should_receive(:h3).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:h3).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.heading3).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:h3).and_return(watir_browser)
+      expect(watir_browser).to receive(:h3).and_return(watir_browser)
       element = watir_page_object.heading3_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -932,13 +932,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the h4" do
-      watir_browser.should_receive(:h4).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:h4).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.heading4).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:h4).and_return(watir_browser)
+      expect(watir_browser).to receive(:h4).and_return(watir_browser)
       element = watir_page_object.heading4_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -957,13 +957,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the h5" do
-      watir_browser.should_receive(:h5).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:h5).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.heading5).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:h5).and_return(watir_browser)
+      expect(watir_browser).to receive(:h5).and_return(watir_browser)
       element = watir_page_object.heading5_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -982,13 +982,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the h6" do
-      watir_browser.should_receive(:h6).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:h6).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.heading6).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:h6).and_return(watir_browser)
+      expect(watir_browser).to receive(:h6).and_return(watir_browser)
       element = watir_page_object.heading6_element
       expect(element).to be_instance_of PageObject::Elements::Heading
     end
@@ -1008,13 +1008,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the p" do
-      watir_browser.should_receive(:p).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:p).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.first_para).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:p).and_return(watir_browser)
+      expect(watir_browser).to receive(:p).and_return(watir_browser)
       element = watir_page_object.first_para_element
       expect(element).to be_instance_of PageObject::Elements::Paragraph
     end
@@ -1033,13 +1033,13 @@ describe PageObject::Accessors do
     end
 
     it "should set the file name" do
-      watir_browser.should_receive(:file_field).and_return(watir_browser)
-      watir_browser.should_receive(:set).with('some_file')
+      expect(watir_browser).to receive(:file_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:set).with('some_file')
       watir_page_object.upload_me = 'some_file'
     end
 
     it "should retrieve a text field element" do
-      watir_browser.should_receive(:file_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:file_field).and_return(watir_browser)
       element = watir_page_object.upload_me_element
       expect(element).to be_instance_of PageObject::Elements::FileField
     end
@@ -1058,13 +1058,13 @@ describe PageObject::Accessors do
     end
 
     it "should click on the area" do
-      watir_browser.should_receive(:area).and_return(watir_browser)
-      watir_browser.should_receive(:click)
+      expect(watir_browser).to receive(:area).and_return(watir_browser)
+      expect(watir_browser).to receive(:click)
       watir_page_object.img_area
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:area).and_return(watir_browser)
+      expect(watir_browser).to receive(:area).and_return(watir_browser)
       element = watir_page_object.img_area_element
       expect(element).to be_instance_of PageObject::Elements::Area
     end
@@ -1119,13 +1119,13 @@ describe PageObject::Accessors do
     end
 
     it "should retrieve the text from the b" do
-      watir_browser.should_receive(:b).and_return(watir_browser)
-      watir_browser.should_receive(:text).and_return("value")
+      expect(watir_browser).to receive(:b).and_return(watir_browser)
+      expect(watir_browser).to receive(:text).and_return("value")
       expect(watir_page_object.bold).to eql "value"
     end
 
     it "should retrieve the element from the page" do
-      watir_browser.should_receive(:b).and_return(watir_browser)
+      expect(watir_browser).to receive(:b).and_return(watir_browser)
       element = watir_page_object.bold_element
       expect(element).to be_instance_of PageObject::Elements::Bold
     end

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -498,26 +498,26 @@ describe PageObject::Accessors do
     it "should get the text from the text area" do
       watir_browser.should_receive(:textarea).and_return(watir_browser)
       watir_browser.should_receive(:value).and_return("123 main street")
-      watir_page_object.address.should == "123 main street"
+      expect(watir_page_object.address).to eql "123 main street"
     end
 
     it "should retrieve a text area element" do
       watir_browser.should_receive(:textarea).and_return(watir_browser)
       element = watir_page_object.address_element
-      element.should be_instance_of PageObject::Elements::TextArea
+      expect(element).to be_instance_of PageObject::Elements::TextArea
     end
   end
 
   describe "select_list accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to :state
-        watir_page_object.should respond_to :state=
-        watir_page_object.should respond_to(:state_element)
+        expect(watir_page_object).to respond_to :state
+        expect(watir_page_object).to respond_to :state=
+        expect(watir_page_object).to respond_to(:state_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.state_element.should == "select_list"
+        expect(block_page_object.state_element).to eql "select_list"
       end
     end
 
@@ -527,7 +527,7 @@ describe PageObject::Accessors do
       selected.should_receive(:text).and_return("OH")
       watir_browser.should_receive(:select_list).and_return watir_browser
       watir_browser.should_receive(:options).and_return([selected])
-      watir_page_object.state.should == "OH"
+      expect(watir_page_object.state).to eql "OH"
     end
 
     it "should set the current item of a select list" do
@@ -539,7 +539,7 @@ describe PageObject::Accessors do
     it "should retreive the select list element" do
       watir_browser.should_receive(:select_list).and_return(watir_browser)
       element = watir_page_object.state_element
-      element.should be_instance_of PageObject::Elements::SelectList
+      expect(element).to be_instance_of PageObject::Elements::SelectList
     end
 
     it "should return list of selection options" do
@@ -552,24 +552,21 @@ describe PageObject::Accessors do
       select_element.should_receive(:options).twice.and_return([option1, option2])
       watir_page_object.should_receive(:state_element).and_return(select_element)
 
-      watir_page_object.state_options.should == ["CA","OH"]
+      expect(watir_page_object.state_options).to eql ["CA","OH"]
     end
-
-
   end
-
 
   describe "check_box accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to :check_active
-        watir_page_object.should respond_to :uncheck_active
-        watir_page_object.should respond_to :active_checked?
-        watir_page_object.should respond_to :active_element
+        expect(watir_page_object).to respond_to :check_active
+        expect(watir_page_object).to respond_to :uncheck_active
+        expect(watir_page_object).to respond_to :active_checked?
+        expect(watir_page_object).to respond_to :active_element
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.active_element.should == "checkbox"
+        expect(block_page_object.active_element).to eql "checkbox"
       end
     end
 
@@ -588,13 +585,13 @@ describe PageObject::Accessors do
     it "should know if a check box element is selected" do
       watir_browser.should_receive(:checkbox).and_return(watir_browser)
       watir_browser.should_receive(:set?).and_return(true)
-      watir_page_object.active_checked?.should be true
+      expect(watir_page_object.active_checked?).to be true
     end
 
     it "should retrieve a checkbox element" do
       watir_browser.should_receive(:checkbox).and_return(watir_browser)
       element = watir_page_object.active_element
-      element.should be_instance_of PageObject::Elements::CheckBox
+      expect(element).to be_instance_of PageObject::Elements::CheckBox
     end
   end
 
@@ -602,13 +599,13 @@ describe PageObject::Accessors do
   describe "radio accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to :select_first
-        watir_page_object.should respond_to :first_selected?
-        watir_page_object.should respond_to(:first_element)
+        expect(watir_page_object).to respond_to :select_first
+        expect(watir_page_object).to respond_to :first_selected?
+        expect(watir_page_object).to respond_to(:first_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.first_element.should == "radio_button"
+        expect(block_page_object.first_element).to eql "radio_button"
       end
     end
 
@@ -627,19 +624,19 @@ describe PageObject::Accessors do
     it "should retrieve a radio button element" do
       watir_browser.should_receive(:radio).and_return(watir_browser)
       element = watir_page_object.first_element
-      element.should be_instance_of PageObject::Elements::RadioButton
+      expect(element).to be_instance_of PageObject::Elements::RadioButton
     end
   end
 
   describe "button accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to :click_me
-        watir_page_object.should respond_to :click_me_element
+        expect(watir_page_object).to respond_to :click_me
+        expect(watir_page_object).to respond_to :click_me_element
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.click_me_element.should == "button"
+        expect(block_page_object.click_me_element).to eql "button"
       end
     end
 
@@ -652,348 +649,348 @@ describe PageObject::Accessors do
     it "should retrieve a button element" do
       watir_browser.should_receive(:button).and_return(watir_browser)
       element = watir_page_object.click_me_element
-      element.should be_instance_of PageObject::Elements::Button
+      expect(element).to be_instance_of PageObject::Elements::Button
     end
   end
 
   describe "div accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:message)
-        watir_page_object.should respond_to(:message_element)
+        expect(watir_page_object).to respond_to(:message)
+        expect(watir_page_object).to respond_to(:message_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.footer_element.should == "div"
+        expect(block_page_object.footer_element).to eql "div"
       end
     end
 
     it "should retrieve the text from a div" do
       watir_browser.should_receive(:div).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("Message from div")
-      watir_page_object.message.should == "Message from div"
+      expect(watir_page_object.message).to eql "Message from div"
     end
 
     it "should retrieve the div element from the page" do
       watir_browser.should_receive(:div).and_return(watir_browser)
       element = watir_page_object.message_element
-      element.should be_instance_of PageObject::Elements::Div
+      expect(element).to be_instance_of PageObject::Elements::Div
     end
   end
 
   describe "span accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:alert_span)
-        watir_page_object.should respond_to(:alert_span_element)
+        expect(watir_page_object).to respond_to(:alert_span)
+        expect(watir_page_object).to respond_to(:alert_span_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.alert_span_element.should == "span"
+        expect(block_page_object.alert_span_element).to eql "span"
       end
     end
 
     it "should retrieve the text from a span" do
       watir_browser.should_receive(:span).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("Alert")
-      watir_page_object.alert_span.should == "Alert"
+      expect(watir_page_object.alert_span).to eql "Alert"
     end
 
     it "should retrieve the span element from the page" do
       watir_browser.should_receive(:span).and_return(watir_browser)
       element = watir_page_object.alert_span_element
-      element.should be_instance_of PageObject::Elements::Span
+      expect(element).to be_instance_of PageObject::Elements::Span
     end
   end
 
   describe "table accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:cart)
-        watir_page_object.should respond_to(:cart_element)
+        expect(watir_page_object).to respond_to(:cart)
+        expect(watir_page_object).to respond_to(:cart_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.cart_element.should == "table"
+        expect(block_page_object.cart_element).to eql "table"
       end
     end
 
     it "should retrieve the table element from the page" do
       watir_browser.should_receive(:table).and_return(watir_browser)
       element = watir_page_object.cart_element
-      element.should be_instance_of PageObject::Elements::Table
+      expect(element).to be_instance_of PageObject::Elements::Table
     end
   end
 
   describe "table cell accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:total)
-        watir_page_object.should respond_to(:total_element)
+        expect(watir_page_object).to respond_to(:total)
+        expect(watir_page_object).to respond_to(:total_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.total_element.should == "cell"
+        expect(block_page_object.total_element).to eql "cell"
       end
     end
 
     it "should retrieve the text for the cell" do
       watir_browser.should_receive(:td).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return('10.00')
-      watir_page_object.total.should == '10.00'
+      expect(watir_page_object.total).to eql '10.00'
     end
 
     it "should retrieve the cell element from the page" do
       watir_browser.should_receive(:td).and_return(watir_browser)
       element = watir_page_object.total_element
-      element.should be_instance_of PageObject::Elements::TableCell
+      expect(element).to be_instance_of PageObject::Elements::TableCell
     end
   end
 
   describe "image accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:logo_element)
+        expect(watir_page_object).to respond_to(:logo_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.logo_element.should == "image"
+        expect(block_page_object.logo_element).to eql "image"
       end
     end
 
     it "should retrieve the image element from the page" do
       watir_browser.should_receive(:image).and_return(watir_browser)
       element = watir_page_object.logo_element
-      element.should be_instance_of PageObject::Elements::Image
+      expect(element).to be_instance_of PageObject::Elements::Image
     end
   end
 
   describe "form accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:login_element)
+        expect(watir_page_object).to respond_to(:login_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.login_element.should == "form"
+        expect(block_page_object.login_element).to eql "form"
       end
     end
 
     it "should retrieve the form element from the page" do
       watir_browser.should_receive(:form).and_return(watir_browser)
       element = watir_page_object.login_element
-      element.should be_instance_of PageObject::Elements::Form
+      expect(element).to be_instance_of PageObject::Elements::Form
     end
   end
 
   describe "list item accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:item_one)
-        watir_page_object.should respond_to(:item_one_element)
+        expect(watir_page_object).to respond_to(:item_one)
+        expect(watir_page_object).to respond_to(:item_one_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.item_one_element.should == "list_item"
+        expect(block_page_object.item_one_element).to eql "list_item"
       end
     end
 
     it "should retrieve the text from the list item" do
       watir_browser.should_receive(:li).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.item_one.should == "value"
+      expect(watir_page_object.item_one).to eql "value"
     end
 
     it "should retrieve the list item element from the page" do
       watir_browser.should_receive(:li).and_return(watir_browser)
       element = watir_page_object.item_one_element
-      element.should be_instance_of PageObject::Elements::ListItem
+      expect(element).to be_instance_of PageObject::Elements::ListItem
     end
   end
 
   describe "unordered list accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:menu_element)
+        expect(watir_page_object).to respond_to(:menu_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.menu_element.should == "unordered_list"
+        expect(block_page_object.menu_element).to eql "unordered_list"
       end
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:ul).and_return(watir_browser)
       element = watir_page_object.menu_element
-      element.should be_instance_of PageObject::Elements::UnorderedList
+      expect(element).to be_instance_of PageObject::Elements::UnorderedList
     end
   end
 
   describe "ordered list accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:top_five_element)
+        expect(watir_page_object).to respond_to(:top_five_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.top_five_element.should == "ordered_list"
+        expect(block_page_object.top_five_element).to eql "ordered_list"
       end
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:ol).and_return(watir_browser)
       element = watir_page_object.top_five_element
-      element.should be_instance_of PageObject::Elements::OrderedList
+      expect(element).to be_instance_of PageObject::Elements::OrderedList
     end
   end
 
   describe "h1 accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:heading1)
-        watir_page_object.should respond_to(:heading1_element)
+        expect(watir_page_object).to respond_to(:heading1)
+        expect(watir_page_object).to respond_to(:heading1_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.heading1_element.should == "h1"
+        expect(block_page_object.heading1_element).to eql "h1"
       end
     end
 
     it "should retrieve the text from the h1" do
       watir_browser.should_receive(:h1).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.heading1.should == "value"
+      expect(watir_page_object.heading1).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:h1).and_return(watir_browser)
       element = watir_page_object.heading1_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
   describe "h2 accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:heading2)
-        watir_page_object.should respond_to(:heading2_element)
+        expect(watir_page_object).to respond_to(:heading2)
+        expect(watir_page_object).to respond_to(:heading2_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.heading2_element.should == "h2"
+        expect(block_page_object.heading2_element).to eql "h2"
       end
     end
 
     it "should retrieve the text from the h2" do
       watir_browser.should_receive(:h2).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.heading2.should == "value"
+      expect(watir_page_object.heading2).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:h2).and_return(watir_browser)
       element = watir_page_object.heading2_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
   describe "h3 accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:heading3)
-        watir_page_object.should respond_to(:heading3_element)
+        expect(watir_page_object).to respond_to(:heading3)
+        expect(watir_page_object).to respond_to(:heading3_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.heading3_element.should == "h3"
+        expect(block_page_object.heading3_element).to eql "h3"
       end
     end
 
     it "should retrieve the text from the h3" do
       watir_browser.should_receive(:h3).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.heading3.should == "value"
+      expect(watir_page_object.heading3).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:h3).and_return(watir_browser)
       element = watir_page_object.heading3_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
   describe "h4 accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:heading4)
-        watir_page_object.should respond_to(:heading4_element)
+        expect(watir_page_object).to respond_to(:heading4)
+        expect(watir_page_object).to respond_to(:heading4_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.heading4_element.should == "h4"
+        expect(block_page_object.heading4_element).to eql "h4"
       end
     end
 
     it "should retrieve the text from the h4" do
       watir_browser.should_receive(:h4).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.heading4.should == "value"
+      expect(watir_page_object.heading4).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:h4).and_return(watir_browser)
       element = watir_page_object.heading4_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
   describe "h5 accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:heading5)
-        watir_page_object.should respond_to(:heading5_element)
+        expect(watir_page_object).to respond_to(:heading5)
+        expect(watir_page_object).to respond_to(:heading5_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.heading5_element.should == "h5"
+        expect(block_page_object.heading5_element).to eql "h5"
       end
     end
 
     it "should retrieve the text from the h5" do
       watir_browser.should_receive(:h5).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.heading5.should == "value"
+      expect(watir_page_object.heading5).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:h5).and_return(watir_browser)
       element = watir_page_object.heading5_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
   describe "h6 accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:heading6)
-        watir_page_object.should respond_to(:heading6_element)
+        expect(watir_page_object).to respond_to(:heading6)
+        expect(watir_page_object).to respond_to(:heading6_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.heading6_element.should == "h6"
+        expect(block_page_object.heading6_element).to eql "h6"
       end
     end
 
     it "should retrieve the text from the h6" do
       watir_browser.should_receive(:h6).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.heading6.should == "value"
+      expect(watir_page_object.heading6).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:h6).and_return(watir_browser)
       element = watir_page_object.heading6_element
-      element.should be_instance_of PageObject::Elements::Heading
+      expect(element).to be_instance_of PageObject::Elements::Heading
     end
   end
 
@@ -1001,37 +998,37 @@ describe PageObject::Accessors do
   describe "p accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:first_para)
-        watir_page_object.should respond_to(:first_para_element)
+        expect(watir_page_object).to respond_to(:first_para)
+        expect(watir_page_object).to respond_to(:first_para_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.first_para_element.should == "p"
+        expect(block_page_object.first_para_element).to eql "p"
       end
     end
 
     it "should retrieve the text from the p" do
       watir_browser.should_receive(:p).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.first_para.should == "value"
+      expect(watir_page_object.first_para).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:p).and_return(watir_browser)
       element = watir_page_object.first_para_element
-      element.should be_instance_of PageObject::Elements::Paragraph
+      expect(element).to be_instance_of PageObject::Elements::Paragraph
     end
   end
 
   describe "file_field accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:upload_me=)
-        watir_page_object.should respond_to(:upload_me_element)
+        expect(watir_page_object).to respond_to(:upload_me=)
+        expect(watir_page_object).to respond_to(:upload_me_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.a_file_element.should == "file_field"
+        expect(block_page_object.a_file_element).to eql "file_field"
       end
     end
 
@@ -1044,19 +1041,19 @@ describe PageObject::Accessors do
     it "should retrieve a text field element" do
       watir_browser.should_receive(:file_field).and_return(watir_browser)
       element = watir_page_object.upload_me_element
-      element.should be_instance_of PageObject::Elements::FileField
+      expect(element).to be_instance_of PageObject::Elements::FileField
     end
   end
 
   describe "area accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:img_area)
-        watir_page_object.should respond_to(:img_area_element)
+        expect(watir_page_object).to respond_to(:img_area)
+        expect(watir_page_object).to respond_to(:img_area_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.img_area_element.should == "area"
+        expect(block_page_object.img_area_element).to eql "area"
       end
     end
 
@@ -1069,18 +1066,18 @@ describe PageObject::Accessors do
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:area).and_return(watir_browser)
       element = watir_page_object.img_area_element
-      element.should be_instance_of PageObject::Elements::Area
+      expect(element).to be_instance_of PageObject::Elements::Area
     end
   end
 
   describe "canvas accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:my_canvas_element)
+        expect(watir_page_object).to respond_to(:my_canvas_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.my_canvas_element.should == "canvas"
+        expect(block_page_object.my_canvas_element).to eql "canvas"
       end
     end
   end
@@ -1088,11 +1085,11 @@ describe PageObject::Accessors do
   describe "audio accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:acdc_element)
+        expect(watir_page_object).to respond_to(:acdc_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.acdc_element.should == "audio"
+        expect(block_page_object.acdc_element).to eql "audio"
       end
     end
   end
@@ -1100,11 +1097,11 @@ describe PageObject::Accessors do
   describe "video accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:movie_element)
+        expect(watir_page_object).to respond_to(:movie_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.movie_element.should == "video"
+        expect(block_page_object.movie_element).to eql "video"
       end
     end
   end
@@ -1112,25 +1109,25 @@ describe PageObject::Accessors do
   describe "b accessors" do
     context "when called on a page object" do
       it "should generate accessor methods" do
-        watir_page_object.should respond_to(:bold)
-        watir_page_object.should respond_to(:bold_element)
+        expect(watir_page_object).to respond_to(:bold)
+        expect(watir_page_object).to respond_to(:bold_element)
       end
 
       it "should call a block on the element method when present" do
-        block_page_object.bold_element.should == "b"
+        expect(block_page_object.bold_element).to eql "b"
       end
     end
 
     it "should retrieve the text from the b" do
       watir_browser.should_receive(:b).and_return(watir_browser)
       watir_browser.should_receive(:text).and_return("value")
-      watir_page_object.bold.should == "value"
+      expect(watir_page_object.bold).to eql "value"
     end
 
     it "should retrieve the element from the page" do
       watir_browser.should_receive(:b).and_return(watir_browser)
       element = watir_page_object.bold_element
-      element.should be_instance_of PageObject::Elements::Bold
+      expect(element).to be_instance_of PageObject::Elements::Bold
     end
   end
 

--- a/spec/page-object/widget_spec.rb
+++ b/spec/page-object/widget_spec.rb
@@ -48,7 +48,7 @@ describe "Widget PageObject Extensions" do
       let(:watir_page_object) { WidgetTestPageObject.new(watir_browser) }
 
       it "should find a gxt_table element" do
-        watir_browser.should_receive(:div).with(:id => 'blah').and_return(watir_browser)
+        expect(watir_browser).to receive(:div).with(:id => 'blah').and_return(watir_browser)
         element = watir_page_object.gxt_table_element(:id => 'blah')
         expect(element).to be_instance_of GxtTable
       end
@@ -59,7 +59,7 @@ describe "Widget PageObject Extensions" do
       let(:selenium_page_object) { WidgetTestPageObject.new(selenium_browser) }
 
       it "should find a gxt_table element" do
-        selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
+        expect(selenium_browser).to receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
         element = selenium_page_object.gxt_table_element(:id => 'blah')
         expect(element).to be_instance_of GxtTable
       end
@@ -80,7 +80,7 @@ describe "Widget PageObject Extensions" do
       let(:default_identifier) { WatirDefaultIdentifier.new(watir_browser) }
 
       def mock_driver_for(tag)
-        watir_browser.should_receive(tag).with(:index => 0).and_return(watir_browser)
+        expect(watir_browser).to receive(tag).with(:index => 0).and_return(watir_browser)
       end
 
       it "should work for a gxt_table" do
@@ -110,19 +110,19 @@ describe "Widget PageObject Extensions" do
       end
 
       it "should retrieve the table element from the page" do
-        watir_browser.should_receive(:div).and_return(watir_browser)
+        expect(watir_browser).to receive(:div).and_return(watir_browser)
         element = watir_page_object.a_table_element
         expect(element).to be_instance_of GxtTable
       end
 
       it "should retrieve all table elements from the page" do
-        watir_browser.should_receive(:divs).and_return([watir_browser])
+        expect(watir_browser).to receive(:divs).and_return([watir_browser])
         element = watir_page_object.some_table_elements
         expect(element[0]).to be_instance_of GxtTable
       end
 
       it "should be able to specify the plural form" do
-        watir_browser.should_receive(:divs).and_return([watir_browser])
+        expect(watir_browser).to receive(:divs).and_return([watir_browser])
         element = watir_page_object.matrix_elements
         expect(element[0]).to be_instance_of WidgetMatrix
       end
@@ -150,22 +150,22 @@ describe "Widget PageObject Extensions" do
       let(:gxt_table_element) { double('gxt_table_element') }
 
       before(:each) do
-        gxt_table_element.stub(:[]).and_return(gxt_table_element)
-        gxt_table_element.stub(:find_elements).and_return(gxt_table_element)
+        allow(gxt_table_element).to receive(:[]).and_return(gxt_table_element)
+        allow(gxt_table_element).to receive(:find_elements).and_return(gxt_table_element)
       end
 
       context "for watir" do
         let(:watir_table) { GxtTable.new(gxt_table_element, :platform => :watir_webdriver) }
 
         it "should return a table row when indexed" do
-          gxt_table_element.stub(:[]).with(1).and_return(gxt_table_element)
+          allow(gxt_table_element).to receive(:[]).with(1).and_return(gxt_table_element)
           expect(watir_table[1]).to be_instance_of PageObject::Elements::TableRow
         end
 
         it "should return the number of rows" do
-          gxt_table_element.stub(:wd).and_return(gxt_table_element)
-          gxt_table_element.should_receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
-          gxt_table_element.should_receive(:size).and_return(2)
+          allow(gxt_table_element).to receive(:wd).and_return(gxt_table_element)
+          expect(gxt_table_element).to receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
+          expect(gxt_table_element).to receive(:size).and_return(2)
           expect(watir_table.rows).to eql 2
         end
       end
@@ -174,18 +174,18 @@ describe "Widget PageObject Extensions" do
         let(:selenium_table) { GxtTable.new(gxt_table_element, :platform => :selenium_webdriver) }
 
         it "should return a table row when indexed" do
-          gxt_table_element.should_receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
+          expect(gxt_table_element).to receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
           expect(selenium_table[1]).to be_instance_of PageObject::Elements::TableRow
         end
 
         it "should return the number of rows" do
-          gxt_table_element.should_receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
-          gxt_table_element.should_receive(:size).and_return(2)
+          expect(gxt_table_element).to receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
+          expect(gxt_table_element).to receive(:size).and_return(2)
           expect(selenium_table.rows).to eql 2
         end
 
         it "should iterate over the table rows" do
-          selenium_table.should_receive(:rows).and_return(2)
+          expect(selenium_table).to receive(:rows).and_return(2)
           count = 0
           selenium_table.each { |e| count += 1 }
           expect(count).to eql 2
@@ -202,7 +202,7 @@ describe "Widget PageObject Extensions" do
       end
 
       it "should find a nested gxt_table" do
-        @watir_driver.should_receive(:div).and_return(@watir_driver)
+        expect(@watir_driver).to receive(:div).and_return(@watir_driver)
         @watir_element.gxt_table_element
       end
     end
@@ -214,7 +214,7 @@ describe "Widget PageObject Extensions" do
       end
 
       it "should find a nested gxt_table" do
-        @selenium_driver.should_receive(:find_element).and_return(@selenium_driver)
+        expect(@selenium_driver).to receive(:find_element).and_return(@selenium_driver)
         @selenium_element.gxt_table_element
       end
     end

--- a/spec/page-object/widget_spec.rb
+++ b/spec/page-object/widget_spec.rb
@@ -50,7 +50,7 @@ describe "Widget PageObject Extensions" do
       it "should find a gxt_table element" do
         watir_browser.should_receive(:div).with(:id => 'blah').and_return(watir_browser)
         element = watir_page_object.gxt_table_element(:id => 'blah')
-        element.should be_instance_of GxtTable
+        expect(element).to be_instance_of GxtTable
       end
     end
 
@@ -61,7 +61,7 @@ describe "Widget PageObject Extensions" do
       it "should find a gxt_table element" do
         selenium_browser.should_receive(:find_element).with(:id, 'blah').and_return(selenium_browser)
         element = selenium_page_object.gxt_table_element(:id => 'blah')
-        element.should be_instance_of GxtTable
+        expect(element).to be_instance_of GxtTable
       end
     end
   end
@@ -85,7 +85,7 @@ describe "Widget PageObject Extensions" do
 
       it "should work for a gxt_table" do
         mock_driver_for :div
-        default_identifier.default_gxt_table_element.should_not be_nil
+        expect(default_identifier.default_gxt_table_element).not_to be_nil
       end
 
     end
@@ -93,38 +93,38 @@ describe "Widget PageObject Extensions" do
     describe "gxt_table accessors" do
       context "when called on a page object" do
         it "should generate accessor methods" do
-          watir_page_object.should respond_to(:a_table_element)
+          expect(watir_page_object).to respond_to(:a_table_element)
         end
 
         it "should generate multiple accessor methods" do
-          watir_page_object.should respond_to(:some_table_elements)
+          expect(watir_page_object).to respond_to(:some_table_elements)
         end
 
         it "should call a block on the element method when present" do
-          watir_page_object.gxt_block_table_element.should == "block_gxt_table"
+          expect(watir_page_object.gxt_block_table_element).to eql "block_gxt_table"
         end
 
         it "should call a block on the elements method when present" do
-          watir_page_object.gxt_multiple_block_table_elements.should == "multiple_block_gxt_table"
+          expect(watir_page_object.gxt_multiple_block_table_elements).to eql "multiple_block_gxt_table"
         end
       end
 
       it "should retrieve the table element from the page" do
         watir_browser.should_receive(:div).and_return(watir_browser)
         element = watir_page_object.a_table_element
-        element.should be_instance_of GxtTable
+        expect(element).to be_instance_of GxtTable
       end
 
       it "should retrieve all table elements from the page" do
         watir_browser.should_receive(:divs).and_return([watir_browser])
         element = watir_page_object.some_table_elements
-        element[0].should be_instance_of GxtTable
+        expect(element[0]).to be_instance_of GxtTable
       end
 
       it "should be able to specify the plural form" do
         watir_browser.should_receive(:divs).and_return([watir_browser])
         element = watir_page_object.matrix_elements
-        element[0].should be_instance_of WidgetMatrix
+        expect(element[0]).to be_instance_of WidgetMatrix
       end
     end
   end
@@ -134,14 +134,14 @@ describe "Widget PageObject Extensions" do
       it "should map watir types to same" do
         [:class, :id, :index, :xpath].each do |t|
           identifier = GxtTable.watir_identifier_for t => 'value'
-          identifier.keys.first.should == t
+          expect(identifier.keys.first).to eql t
         end
       end
 
       it "should map selenium types to same" do
         [:class, :id, :index, :name, :xpath].each do |t|
           key, value = GxtTable.selenium_identifier_for t => 'value'
-          key.should == t
+          expect(key).to eql t
         end
       end
     end
@@ -159,14 +159,14 @@ describe "Widget PageObject Extensions" do
 
         it "should return a table row when indexed" do
           gxt_table_element.stub(:[]).with(1).and_return(gxt_table_element)
-          watir_table[1].should be_instance_of PageObject::Elements::TableRow
+          expect(watir_table[1]).to be_instance_of PageObject::Elements::TableRow
         end
 
         it "should return the number of rows" do
           gxt_table_element.stub(:wd).and_return(gxt_table_element)
           gxt_table_element.should_receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
           gxt_table_element.should_receive(:size).and_return(2)
-          watir_table.rows.should == 2
+          expect(watir_table.rows).to eql 2
         end
       end
 
@@ -175,20 +175,20 @@ describe "Widget PageObject Extensions" do
 
         it "should return a table row when indexed" do
           gxt_table_element.should_receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
-          selenium_table[1].should be_instance_of PageObject::Elements::TableRow
+          expect(selenium_table[1]).to be_instance_of PageObject::Elements::TableRow
         end
 
         it "should return the number of rows" do
           gxt_table_element.should_receive(:find_elements).with(:xpath, ".//descendant::tr").and_return(gxt_table_element)
           gxt_table_element.should_receive(:size).and_return(2)
-          selenium_table.rows.should == 2
+          expect(selenium_table.rows).to eql 2
         end
 
         it "should iterate over the table rows" do
           selenium_table.should_receive(:rows).and_return(2)
           count = 0
           selenium_table.each { |e| count += 1 }
-          count.should == 2
+          expect(count).to eql 2
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ end
 
 def mock_adapter(browser, page_object)
   adapter = double('adapter')
-  adapter.stub(:is_for?).with(anything()).and_return false
+  allow(adapter).to receive(:is_for?).with(anything()).and_return false
   allow(adapter).to receive(:is_for?).with(browser).and_return true
   allow(adapter).to receive(:create_page_object).and_return page_object
   adapter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,16 +17,16 @@ require 'page-object'
 
 def mock_watir_browser
   watir_browser = double('watir')
-  watir_browser.stub(:is_a?).with(anything()).and_return(false)
-  watir_browser.stub(:is_a?).with(Watir::Browser).and_return(true)
+  allow(watir_browser).to receive(:is_a?).with(anything()).and_return(false)
+  allow(watir_browser).to receive(:is_a?).with(Watir::Browser).and_return(true)
   watir_browser
 end
 
 
 def mock_selenium_browser
   selenium_browser = double('selenium')
-  selenium_browser.stub(:is_a?).with(Watir::Browser).and_return(false)
-  selenium_browser.stub(:is_a?).with(Selenium::WebDriver::Driver).and_return(true)
+  allow(selenium_browser).to receive(:is_a?).with(Watir::Browser).and_return(false)
+  allow(selenium_browser).to receive(:is_a?).with(Selenium::WebDriver::Driver).and_return(true)
   selenium_browser
 end
 
@@ -34,11 +34,11 @@ end
 def mock_adapter(browser, page_object)
   adapter = double('adapter')
   adapter.stub(:is_for?).with(anything()).and_return false
-  adapter.stub(:is_for?).with(browser).and_return true
-  adapter.stub(:create_page_object).and_return page_object
+  allow(adapter).to receive(:is_for?).with(browser).and_return true
+  allow(adapter).to receive(:create_page_object).and_return page_object
   adapter
 end
 
 def mock_adapters(adapters)
-  PageObject::Platforms.stub(:get).and_return adapters
+  allow(PageObject::Platforms).to receive(:get).and_return adapters
 end


### PR DESCRIPTION
Right click on Watir was not defined, so added that. Also added methods to access the size and location of elements.

Previously these methods were all being passed to webdriver, and so giving a deprecation warning.