### PR TITLE
Allow style method to be called without parameter

### DIFF
--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -44,7 +44,7 @@ module PageObject
       #
       # get the value of the given CSS property
       #
-      def style(property)
+      def style(property = nil)
         element.style property
       end
 


### PR DESCRIPTION
We should allow the element.style method to be called without a parameter, so that the user can retrieve an elements styles. The underlying watir-webdriver method Page-Object calls is designed to handle this scenario. I understand that we can workaround this by calling with nil, but thats no fun :-1: 


Current Page-Object method (without fix)
```ruby
  #
  # get the value of the given CSS property
  #
      def style(property)
        element.style property
      end
```

New Page-Object method (with fix)
```ruby
  #
  # get the value of the given CSS property
  #
      def style(property = nil)
        element.style property
      end
```

Underlying watir-webdriver method being called (note support for parameterless call)
```ruby
  #
    # Returns given style property of this element.
    #
    # @example
    #   browser.button(value: "Delete").style           #=> "border: 4px solid red;"
    #   browser.button(value: "Delete").style("border") #=> "4px solid red"
    #
    # @param [String] property
    # @return [String]
    #

    def style(property = nil)
      if property
        assert_exists
        element_call { @element.style property }
      else
        attribute_value("style").to_s.strip
      end
    end

    #
    # Cast this Element instance to a more specific subtype.
    #
    # @example
    #   browser.element(xpath: "//input[@type='submit']").to_subtype
    #   #=> #<Watir::Button>
    #
```