### PR TITLE
Update frame and iframe accessors

### DIFF
--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -153,7 +153,7 @@ module PageObject
     # @param block that contains the calls to elements that exist inside the frame.
     #
     def in_frame(identifier, frame=nil, &block)
-      frame = [] if frame.nil?
+      frame = frame.nil? ? [] : frame.dup
       frame << {frame: identifier}
       block.call(frame)
     end
@@ -177,7 +177,7 @@ module PageObject
     # @param block that contains the calls to elements that exist inside the iframe.
     #
     def in_iframe(identifier, frame=nil, &block)
-      frame = [] if frame.nil?
+      frame = frame.nil? ? [] : frame.dup
       frame << {iframe: identifier}
       block.call(frame)
     end


### PR DESCRIPTION
Modified the `in_iframe` and `in_frame` accessors. 

Previously, if you had a frame or iframe ("frame_a") with a nested frame/iframe ("frame_b"), you could not model elements in "frame_a" AND model "frame_b" via a nested `in_iframe` or `in_frame` call.

Example:

```
in_iframe(:id => "frame_a") do | frame_a |
     div(:example_div, :xpath => "//span/div[@example='1']", :frame => frame_a)
     in_iframe({:id => "frame_b"}, frame_a) do | frame_b |
         div(:another_example, :id => "example-id", :frame => frame_b)
     end
end
```

In this snippet, `another_example` should work as expected; but prior to this change, `:example_div` would not be locatable because its `:frame` argument would have had `frame_b` added to it.

We can work around this without this patch by simply putting nested frames/iframes in their own `in_iframe` calls, like this:

 
```
in_iframe(:id => "frame_a") do | frame_a |
     div(:example_div, :xpath => "//span/div[@example='1']", :frame => frame_a)
end

in_iframe(:id => "frame_a") do | frame_a |
     in_iframe({:id => "frame_b"}, frame_a) do | frame_b |
         div(:another_example, :id => "example-id", :frame => frame_b)
     end
end
```

or by `dup`ing the frame (e.g., `frame_a`) ourselves before passing it to the nested `in_iframe` call. I figured it would be easiest to have the `in_*frame` accessors make this safe themselves.