### PR TITLE
use webdrivers and chrome stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,15 @@
 sudo: required
 dist: trusty
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 cache: bundler
+addons:
+  chrome: stable
 before_script:
- - export CHROME_BIN=/usr/bin/google-chrome
  - export DISPLAY=:99.0
  - sh -e /etc/init.d/xvfb start
- - sudo apt-get update
- - sudo apt-get install -y libappindicator1 fonts-liberation
- - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
- - sudo dpkg -i google-chrome*.deb
- - CHROMEDRIVER_VERSION=$(curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
- - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
- - unzip chromedriver_linux64.zip
- - chmod +x chromedriver
- - sudo mv chromedriver /usr/local/bin
 
 script: bundle exec rake $RAKE_TASK
 env:

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack', '~> 1.0'
   s.add_development_dependency 'coveralls', '~> 0.8.1'
   s.add_development_dependency 'net-http-persistent'
+  s.add_development_dependency 'webdrivers'
 
 end


### PR DESCRIPTION
My feelings won't be hurt if you don't want to use the `webdrivers` gem, but you don't need as much stuff in your Travis file any more... This runs a little faster, but your tests are already short and fast.

The legit downside to using the gem is that depending on your ruby management you might have to `gem uninstall webdrivers` to run projects that don't use the gem, after running page object specs. 