### PR TITLE
Fix bug with selecting an option by text when using PageObject::PagePopulator#populate_page_with

### DIFF
--- a/features/populate_page_with.feature
+++ b/features/populate_page_with.feature
@@ -21,3 +21,6 @@ Feature: Populate Page With
     And the First check box should be selected
     And the "Butter" radio button should be selected
     And the "muen" radio button should be selected in the group
+    When I populate the page with the data:
+      | sel_list_id | option3 |
+    Then the selected option should be "Test/Test 3"

--- a/features/populate_page_with.feature
+++ b/features/populate_page_with.feature
@@ -1,0 +1,23 @@
+Feature: Populate Page With
+  In order to quickly fill out forms on a page
+  A tester will use the populate_page_with method
+  To fill in text, select options, check boxes, and select radio buttons
+
+
+  Background:
+    Given I am on the static elements page
+
+  Scenario:
+    When I populate the page with the data:
+      | text_field_id   | abcDEF           |
+      | text_area_id    | abcdefghijklmnop |
+      | sel_list_id     | Test 2           |
+      | cb_id           | check            |
+      | butter_id       | check            |
+      | favorite_cheese | muen             |
+    Then the text field should contain "abcDEF"
+    And the text area should contain "abcdefghijklmnop"
+    And the selected option should be "Test 2"
+    And the First check box should be selected
+    And the "Butter" radio button should be selected
+    And the "muen" radio button should be selected in the group

--- a/features/step_definitions/populate_page_with_steps.rb
+++ b/features/step_definitions/populate_page_with_steps.rb
@@ -1,0 +1,3 @@
+When(/^I populate the page with the data:$/) do |table|
+  @page.populate_page_with table.rows_hash
+end

--- a/lib/page-object/page_populator.rb
+++ b/lib/page-object/page_populator.rb
@@ -8,7 +8,7 @@ module PageObject
     # matching the Hash key to the name you provided when declaring
     # the element on your page.
     #
-    # Checkboxe and Radio Button values must be true or false.
+    # Checkbox and Radio Button values must be true or false.
     #
     # @example
     #   class ExamplePage
@@ -24,7 +24,7 @@ module PageObject
     #   example_page = ExamplePage.new(@browser)
     #   example_page.populate_page_with :username => 'a name', :active => true
     #
-    # @param [Hash] the data to use to populate this page.  The key
+    # @param data [Hash] the data to use to populate this page.  The key
     # can be either a string or a symbol.  The value must be a string
     # for TextField, TextArea, SelectList, and FileField and must be true or
     # false for a Checkbox or RadioButton.
@@ -58,9 +58,9 @@ module PageObject
       return self.send("select_#{key}", value)
     end
 
-  def populate_select_list(key, value)
+    def populate_select_list(key, value)
       select_element = self.send("#{key}_element")
-      if select_element.options.include?(value)
+      if select_element.options.map(&:text).include?(value)
         select_element.select(value)
       else
         select_element.select_value(value)

--- a/lib/page-object/page_populator.rb
+++ b/lib/page-object/page_populator.rb
@@ -60,11 +60,8 @@ module PageObject
 
     def populate_select_list(key, value)
       select_element = self.send("#{key}_element")
-      if select_element.options.map(&:text).include?(value)
-        select_element.select(value)
-      else
-        select_element.select_value(value)
-      end
+      return select_element.select(value) if select_element.include?(value)
+      select_element.select_value(value)
     end
 
     def is_text?(key)

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -15,8 +15,6 @@ end
 describe PageObject::PagePopulator  do
   let(:browser) { mock_watir_browser }
   let(:page_object) { PageObjectTestPageObject.new(browser) }
-  let(:options) { PageObject::Elements::Option.new(browser) }
-
 
   it "should set a value in a text field" do
     expect(page_object).to receive(:tf=).with('value')
@@ -55,9 +53,10 @@ describe PageObject::PagePopulator  do
 
   it "should set a value in a select list" do
     list = double('sl')
+    option = double('option')
     expect(page_object).to receive(:sl_element).and_return(list)
-    expect(list).to receive(:options).and_return([options])
-    allow(options).to receive(:text)
+    expect(list).to receive(:options).and_return([option])
+    allow(option).to receive(:text)
     expect(list).to receive(:select_value).with('value').and_return('value')
     page_object.populate_page_with('sl' => 'value')
   end

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -53,10 +53,8 @@ describe PageObject::PagePopulator  do
 
   it "should set a value in a select list" do
     list = double('sl')
-    option = double('option')
     expect(page_object).to receive(:sl_element).and_return(list)
-    expect(list).to receive(:options).and_return([option])
-    allow(option).to receive(:text)
+    allow(list).to receive(:include?)
     expect(list).to receive(:select_value).with('value').and_return('value')
     page_object.populate_page_with('sl' => 'value')
   end

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -59,6 +59,14 @@ describe PageObject::PagePopulator  do
     page_object.populate_page_with('sl' => 'value')
   end
 
+  it "should set a value in a select list by text" do
+    list = double('sl')
+    expect(page_object).to receive(:sl_element).and_return(list)
+    allow(list).to receive(:include?).and_return(true)
+    expect(list).to receive(:select).with('text').and_return('text')
+    page_object.populate_page_with('sl' => 'text')
+  end
+
   it "should set a value in a file field" do
     expect(page_object).to receive(:ff=).with('value')
     allow(page_object).to receive(:is_enabled?).and_return(true)

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -15,6 +15,8 @@ end
 describe PageObject::PagePopulator  do
   let(:browser) { mock_watir_browser }
   let(:page_object) { PageObjectTestPageObject.new(browser) }
+  let(:options) { PageObject::Elements::Option.new(browser) }
+
 
   it "should set a value in a text field" do
     expect(page_object).to receive(:tf=).with('value')
@@ -54,8 +56,9 @@ describe PageObject::PagePopulator  do
   it "should set a value in a select list" do
     list = double('sl')
     expect(page_object).to receive(:sl_element).and_return(list)
-    expect(list).to receive(:options).and_return(['value'])
-    expect(list).to receive(:select).with('value')
+    expect(list).to receive(:options).and_return([options])
+    allow(options).to receive(:text)
+    expect(list).to receive(:select_value).with('value').and_return('value')
     page_object.populate_page_with('sl' => 'value')
   end
 

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -54,7 +54,7 @@ describe PageObject::PagePopulator  do
   it "should set a value in a select list" do
     list = double('sl')
     expect(page_object).to receive(:sl_element).and_return(list)
-    allow(list).to receive(:include?)
+    allow(list).to receive(:include?).and_return(false)
     expect(list).to receive(:select_value).with('value').and_return('value')
     page_object.populate_page_with('sl' => 'value')
   end


### PR DESCRIPTION
https://github.com/cheezy/page-object/issues/437

Fix bug with selecting an option by text when using
PageObject::PagePopulator#populate_page_with

The conditional to check whether the option passed was text would never
trigger as it was checking for the text against an array of
PageObject::Elements::Options rather than their text. Updated the
conditional to map the text of the options first.

Fix small typo in comment and yarddoc in page_populator.rb

Add feature test for populate_page_with functionality