### PR TITLE
fix wrapping of Selenium Drivers in Watir Browsers

### DIFF
--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -76,7 +76,7 @@ module PageObject
   def initialize_browser(root)
     @root_element = PageObject::Platforms::Watir.root_element_for root
     @browser = root 
-    @platform = PageObject::Platforms::Watir::PageObject.new @browser
+    @platform = PageObject::Platforms::Watir.create_page_object @browser
   end
 
   # @private

--- a/lib/page-object/platforms/watir.rb
+++ b/lib/page-object/platforms/watir.rb
@@ -34,8 +34,8 @@ module PageObject
       end
 
       def self.selenium_browser(root)
-        return Watir::Browser.new(root) if root.is_a?(::Selenium::WebDriver::Driver)
-        Watir::Browser.new(Selenium::WebDriver::Driver.new(root.send(:bridge)))
+        return ::Watir::Browser.new(root) if root.is_a?(::Selenium::WebDriver::Driver)
+        ::Watir::Browser.new(Selenium::WebDriver::Driver.new(root.send(:bridge)))
       end
 
       def self.watir?(browser)


### PR DESCRIPTION
I was able to reproduce #439, and this seems to fix it. Not really sure how this code is actually working, so I'm not sure how to add the right mocks to create specs for it, but this needs a spec. @cheezy we can review this tomorrow.