### PR TITLE
Gemfile: use https source for rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # adding rake so travis-ci will build properly
 gem 'rake'


### PR DESCRIPTION
This PR changes the `source` in the Gemfile to point to `https`.