### PR TITLE
Wrap the text being looked for in table row lookup with Regexp.escape()

### DIFF
--- a/features/html/static_elements.html
+++ b/features/html/static_elements.html
@@ -119,6 +119,17 @@
       </tbody>
     </table>
 
+    <table id='table_with_regex' border='1'>
+      <tr>
+        <td>Price1 |</td>
+        <td>$420.99</td>
+      </tr>
+      <tr>
+        <td>Price |</td>
+        <td>$69.99</td>
+      </tr>
+    </table>
+
     <form method="get" action="success.html">
         <input id='button_id' name='button_name' class='button_class' type="submit" value="Click Me"/>
         <input id='button_image_id' type='image' src='images/submit.gif' alt='Submit'/>

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -304,3 +304,7 @@ end
 Then(/the element centre should be greater than element x position/) do
   expect(@element.centre['x']).to be > @element.location.x
 end
+
+When(/^I retrieve a table element with regex characters$/) do
+  @element = @page.table_with_regex_element
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,3 @@
 Before do
-  @browser = PageObject::PersistantBrowser.get_browser
+  @browser = PageObject::PersistentBrowser.get_browser
 end

--- a/features/support/page.rb
+++ b/features/support/page.rb
@@ -134,6 +134,7 @@ class Page
   table(:table_class_index, :class => "table_class", :index => 0)
   table(:table_name_index, :name => "table_name", :index => 0)
   table(:table_with_thead_id, :id => 'table_with_thead_id')
+  table(:table_with_regex, :id => 'table_with_regex')
 
   cell(:cell_id, :id => 'cell_id')
   cell(:cell_name, :name => 'cell_name')

--- a/features/support/persistent_browser.rb
+++ b/features/support/persistent_browser.rb
@@ -1,7 +1,7 @@
 require 'selenium/webdriver/remote/http/persistent'
 
 module PageObject
-  module PersistantBrowser
+  module PersistentBrowser
     @@browser = false
     def self.get_browser
       if !@@browser

--- a/features/table.feature
+++ b/features/table.feature
@@ -108,3 +108,10 @@ Feature: Table
   Scenario: Getting the text from a table
     Then I should see the text includes "Data1" when I retrieve it by "id"
     And I should see the text includes "Data2" when I retrieve it by "id"
+
+  Scenario: Get rows by text with special chars
+    When I retrieve a table element with regex characters
+    Then the data for row "Price1 |" should be "Price1 |" and "$420.99"
+    And the data for row "rice |" should be "Price |" and "$69.99"
+    And the data for row "$420.99" should be "Price1 |" and "$420.99"
+    And the data for row "$420" should be "Price1 |" and "$420.99"

--- a/lib/page-object/elements/table.rb
+++ b/lib/page-object/elements/table.rb
@@ -58,7 +58,7 @@ module PageObject
       def find_index(what)
         return what if what.is_a? Integer
         row_items.find_index do |row|
-          row.cell(text: /#{what}/).exist?
+          row.cell(text: /#{Regexp.escape(what)}/).exist?
         end
       end
     end


### PR DESCRIPTION
in order to allow for finding table rows with characters special to
regexes, i.e. $, ., |, /

Add feature test and test data

Fix typo in PersistantBrowser module