### PR TITLE
watir 6.8 removed select_text as a separate file

### DIFF
--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -1,5 +1,4 @@
 require 'page-object/nested_elements'
-require 'watir/extensions/select_text'
 
 module PageObject
   module Elements

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(pkg|spec|features|coverage)/}) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'watir', '~> 6.7'
+  s.add_dependency 'watir', '~> 6.8'
   s.add_dependency 'selenium-webdriver', '~> 3.0'
   s.add_dependency 'page_navigation', '>= 0.10'
 


### PR DESCRIPTION
JavaScript things were reworked for Watir 6.8 and this was removed as an extension and is now always available.