### PR TITLE
Use visible text to find index by regex to avoid Watir deprecation warning

### DIFF
--- a/lib/page-object/elements/table.rb
+++ b/lib/page-object/elements/table.rb
@@ -75,7 +75,7 @@ module PageObject
       def find_index(what)
         return what if what.is_a? Integer
         row_items.find_index do |row|
-          row.cell(text: /#{Regexp.escape(what)}/).exist?
+          row.cell(visible_text: /#{Regexp.escape(what)}/).exist?
         end
       end
     end


### PR DESCRIPTION
I found that I got this warning from watir when using the following table_element syntax to click a row in a table for one of my tests:

`2018-01-19 12:36:38 WARN Watir [DEPRECATION] :text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead.`

`table_element["text in table cell"].click`

Changing the `find_index` method to use the new `visible_text` locator did not trigger the deprecation warning. I ran `rspec spec/` and `cucumber features/` and all tests passed. I didn't add any tests because I assume that there are already tests in place for this method and this is just to stay up to date with Watir rather than a new feature.

Let me know if there is anything else you'd like me to test this change with in order to get it merged.