### PR TITLE
Alias when_visible with when_present

### DIFF
--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -133,6 +133,7 @@ module PageObject
         element.wait_until(timeout: timeout, message: "Element not present in #{timeout} seconds", &:present?)
         self
       end
+      alias_method :when_visible, :when_present
 
       #
       # Waits until the element is not present
@@ -143,27 +144,7 @@ module PageObject
       def when_not_present(timeout=::PageObject.default_element_wait)
         element.wait_while(timeout: timeout, message: "Element still present in #{timeout} seconds", &:present?)
       end
-
-      #
-      # Waits until the element is visible
-      #
-      # @param [Integer] (defaults to: 5) seconds to wait before timing out
-      #
-      def when_visible(timeout=::PageObject.default_element_wait)
-        when_present(timeout)
-        element.wait_until(timeout: timeout, message: "Element not visible in #{timeout} seconds", &:visible?)
-        self
-      end
-
-      #
-      # Waits until the element is not visible
-      #
-      # @param [Integer] (defaults to: 5) seconds to wait before timing out
-      #
-      def when_not_visible(timeout=::PageObject.default_element_wait)
-        when_present(timeout)
-        element.wait_while(timeout: timeout, message: "Element still visible after #{timeout} seconds", &:visible?)
-      end
+      alias_method :when_not_visible, :when_not_present
 
       #
       # Waits until the block returns true

--- a/spec/page-object/elements/watir_element_spec.rb
+++ b/spec/page-object/elements/watir_element_spec.rb
@@ -98,21 +98,18 @@ describe "Element for Watir" do
 
   it "should be able to block until it is visible" do
     allow(watir_driver).to receive(:wait_until).with(timeout: 10, message: "Element not present in 10 seconds")
-    allow(watir_driver).to receive(:wait_until).with(timeout: 10, message: "Element not visible in 10 seconds")
     watir_element.when_visible(10)
   end
   
   it "should return the element when it is visible" do
     allow(watir_driver).to receive(:wait_until).with(timeout: 10, message: "Element not present in 10 seconds")
-    allow(watir_driver).to receive(:wait_until).with(timeout: 10, message: "Element not visible in 10 seconds")
     allow(watir_driver).to receive(:displayed?).and_return(true)
     element = watir_element.when_visible(10)
     expect(element).to equal watir_element
   end
 
   it "should be able to block until it is not visible" do
-    allow(watir_driver).to receive(:wait_until).with(timeout: 10, message: "Element not present in 10 seconds")
-    allow(watir_driver).to receive(:wait_while).with(timeout: 10, message: "Element still visible after 10 seconds")
+    allow(watir_driver).to receive(:wait_while).with(timeout: 10, message: "Element still present in 10 seconds")
     allow(watir_driver).to receive(:displayed?).and_return(false)
     watir_element.when_not_visible(10)
   end


### PR DESCRIPTION
This change will:
* Alias `#when_visible` with `#when_present`
* Alias `#when_not_visible` with `#when_not_present`

The existing *_visible methods did not add functionality:
* For `#when_visible`, it waited for the element to be present and then waited for the element to be visible. If an element is present, it exists and is visible. Therefore, the second wait on visibility is not necessary.
* For `#when_not_visible`, the method did not actually work. It waited for the element to be present (ie calling `#when_present`) and then waited for it to be hidden. This should have been calling `#when_not_present`. However, like above, this is not necessary.