### PR TITLE
Replace #visible? with #present?

### DIFF
--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -67,11 +67,11 @@ Then /^I should know it exists$/ do
 end
 
 Then /^I should know it is visible$/ do
-  expect(@element.visible?).to be true
+  expect(@element.present?).to be true
 end
 
 Then /^I should know it is not visible$/ do
-  expect(@element.visible?).to be false
+  expect(@element.present?).to be false
 end
 
 Then /^I should know the text is "(.*)"$/ do |text|

--- a/features/step_definitions/frames_steps.rb
+++ b/features/step_definitions/frames_steps.rb
@@ -135,9 +135,9 @@ Given /^I am on the frame section page$/ do
 end
 
 Then /^I should be able to access an element in the frame in the section repeatedly$/ do
-  expect(@page.p_on_page_element).to be_visible
-  expect(@page.frame_section.p_in_section_element).to be_visible
-  expect(@page.frame_section.success_element).to be_visible
+  expect(@page.p_on_page_element).to be_present
+  expect(@page.frame_section.p_in_section_element).to be_present
+  expect(@page.frame_section.success_element).to be_present
   expect(@page.frame_section.success_element.text).to eq 'this link should open the page success page'
   @page.frame_section.success
   expect(@page.text.strip).to eq 'Success'

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -272,6 +272,6 @@ When(/^I have a page section$/) do
 end
 
 Then(/^methods called on the section are passed to the root if missing$/) do
-  expect(-> { @section.visible? }).not_to raise_error
-  expect(@section.visible?).to be true
+  expect(-> { @section.present? }).not_to raise_error
+  expect(@section.present?).to be true
 end

--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -49,7 +49,7 @@ module PageObject
       #
       def check_visible(timeout=::PageObject.default_element_wait)
         timed_loop(timeout) do |element|
-          element.visible?
+          element.present?
         end
       end
 

--- a/lib/page-object/page_populator.rb
+++ b/lib/page-object/page_populator.rb
@@ -99,7 +99,7 @@ module PageObject
       return false if is_radiobuttongroup?(receiver, key)
       return true if (receiver.send "#{key}_element").tag_name == "textarea"
       element = receiver.send("#{key}_element")
-      element.enabled? and element.visible?
+      element.enabled? and element.present?
     end
   end
 end

--- a/spec/page-object/elements/element_spec.rb
+++ b/spec/page-object/elements/element_spec.rb
@@ -103,8 +103,8 @@ describe "Element" do
     end
 
     it 'should check if the element is visible' do
-      expect(native).to receive(:visible?).and_return(false)
-      expect(native).to receive(:visible?).and_return(true)
+      expect(native).to receive(:present?).and_return(false)
+      expect(native).to receive(:present?).and_return(true)
       expect(element.check_visible).to be true
     end
 

--- a/spec/page-object/page_populator_spec.rb
+++ b/spec/page-object/page_populator_spec.rb
@@ -56,7 +56,7 @@ describe PageObject::PagePopulator  do
     expect(page_object).not_to receive(:tf=)
     expect(page_object).to receive(:tf_element).twice.and_return(browser)
     expect(browser).to receive(:enabled?).and_return(true)
-    expect(browser).to receive(:visible?).and_return(false)
+    expect(browser).to receive(:present?).and_return(false)
     expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('tf' => true)
   end
@@ -114,7 +114,7 @@ describe PageObject::PagePopulator  do
     expect(page_object).not_to receive(:check_cb)
     expect(page_object).to receive(:cb_element).twice.and_return(browser)
     expect(browser).to receive(:enabled?).and_return(true)
-    expect(browser).to receive(:visible?).and_return(false)
+    expect(browser).to receive(:present?).and_return(false)
     expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('cb' => true)
   end
@@ -131,7 +131,7 @@ describe PageObject::PagePopulator  do
     expect(page_object).not_to receive(:select_rb)
     expect(page_object).to receive(:rb_element).twice.and_return(browser)
     expect(browser).to receive(:enabled?).and_return(true)
-    expect(browser).to receive(:visible?).and_return(false)
+    expect(browser).to receive(:present?).and_return(false)
     expect(browser).to receive(:tag_name).and_return('input')
     page_object.populate_page_with('rb' => true)
   end


### PR DESCRIPTION
Fixes the deprecation warning from Watir about using Element#visible? (#467). All usages have been replaced by Element#present?.