### PR TITLE
Replace :text locator with RegExp values with :visible_text

### DIFF
--- a/lib/page-object/elements/table.rb
+++ b/lib/page-object/elements/table.rb
@@ -75,7 +75,7 @@ module PageObject
       def find_index(what)
         return what if what.is_a? Integer
         row_items.find_index do |row|
-          row.cell(text: /#{Regexp.escape(what)}/).exist?
+          row.cell(visible_text: /#{Regexp.escape(what)}/).exist?
         end
       end
     end


### PR DESCRIPTION
Small modification to a locator on the Table class to prevent Watir deprecation warnings.