### PR TITLE
Add date_field accessor

### DIFF
--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -206,6 +206,32 @@ module PageObject
     end
 
     #
+    # adds four methods to the page object - one to set value in a date field,
+    # another to retrieve value from a date field, another to return the date
+    # field element, another to check the date field's existence.
+    #
+    # @example
+    #   date_field(:date_of_birth, :id => "date_of_birth")
+    #   # will generate 'date_of_birth', 'date_of_birth=', 'date_of_birth_element',
+    #   # 'date_of_birth?' methods
+    #
+    # @param [String] the name used for the generated methods
+    # @param [Hash] identifier how we find a date field.
+    # @param optional block to be invoked when element method is called
+    #
+    def date_field(name, identifier={:index => 0}, &block)
+      standard_methods(name, identifier, 'date_field_for', &block)
+      define_method(name) do
+        return platform.date_field_value_for identifier.clone unless block_given?
+        self.send("#{name}_element").value
+      end
+      define_method("#{name}=") do |value|
+        return platform.date_field_value_set(identifier.clone, value) unless block_given?
+        self.send("#{name}_element").value = value
+      end
+    end
+
+    #
     # adds three methods to the page object - one to get the text from a hidden field,
     # another to retrieve the hidden field element, and another to check the hidden
     # field's existence.

--- a/lib/page-object/elements.rb
+++ b/lib/page-object/elements.rb
@@ -29,6 +29,7 @@ end
 require 'page-object/elements/element'
 require 'page-object/elements/link'
 require 'page-object/elements/text_field'
+require 'page-object/elements/date_field'
 require 'page-object/elements/select_list'
 require 'page-object/elements/check_box'
 require 'page-object/elements/button'

--- a/lib/page-object/elements/date_field.rb
+++ b/lib/page-object/elements/date_field.rb
@@ -1,0 +1,10 @@
+module PageObject
+  module Elements
+    class DateField < Element
+
+    end
+
+    ::PageObject::Elements.type_to_class[:date] = ::PageObject::Elements::DateField
+  end
+end
+

--- a/lib/page-object/locator_generator.rb
+++ b/lib/page-object/locator_generator.rb
@@ -121,6 +121,7 @@ module PageObject
 
     ADVANCED_ELEMENTS = %i(
         text_field
+        date_field
         hidden_field
         text_area
         select_list

--- a/lib/page-object/platforms/watir/page_object.rb
+++ b/lib/page-object/platforms/watir/page_object.rb
@@ -232,6 +232,37 @@ module PageObject
         end
 
         #
+        # platform method to get the value stored in a date field
+        # See PageObject::Accessors#date_field
+        #
+        def date_field_value_for(identifier)
+          process_watir_call("date_field(identifier).value", Elements::DateField, identifier)
+        end
+
+        #
+        # platform method to set the value for a date field
+        # See PageObject::Accessors#date_field
+        #
+        def date_field_value_set(identifier, value)
+          process_watir_call("date_field(identifier).set(value)", Elements::DateField, identifier, value)
+        end
+
+        #
+        # platform method to retrieve a date field element
+        # See PageObject::Accessors#date_field
+        #
+        def date_field_for(identifier)
+          find_watir_element("date_field(identifier)", Elements::DateField, identifier)
+        end
+
+        #
+        # platform method to retrieve an array of date field elements
+        #
+        def date_fields_for(identifier)
+          find_watir_elements("date_fields(identifier)", Elements::DateField, identifier)
+        end
+
+        #
         # platform method to get the value stored in a hidden field
         # See PageObject::Accessors#hidden_field
         #

--- a/page-object.gemspec
+++ b/page-object.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(pkg|spec|features|coverage)/}) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'watir', '~> 6.8'
+  s.add_dependency 'watir', '>= 6.10.3'
   s.add_dependency 'selenium-webdriver', '~> 3.0'
   s.add_dependency 'page_navigation', '>= 0.10'
 

--- a/spec/page-object/watir_accessors_spec.rb
+++ b/spec/page-object/watir_accessors_spec.rb
@@ -8,6 +8,7 @@ class WatirAccessorsTestPageObject
   expected_element :google_search
   link(:google_search, :link => 'Google Search')
   text_field(:first_name, :id => 'first_name')
+  date_field(:date_of_birth, :id => 'date_of_birth')
   hidden_field(:social_security_number, :id => 'ssn')
   text_area(:address, :id => 'address')
   select_list(:state, :id => 'state')
@@ -46,6 +47,9 @@ class WatirBlockPageObject
 
   text_field :first_name do |element|
     "text_field"
+  end
+  date_field :date_of_birth do |element|
+    "date_field"
   end
   hidden_field :secret do |element|
     "hidden_field"
@@ -479,6 +483,39 @@ describe PageObject::Accessors do
       expect(watir_browser).to receive(:text_field).and_return(watir_browser)
       element = watir_page_object.first_name_element
       expect(element).to be_instance_of PageObject::Elements::TextField
+    end
+  end
+
+  describe "date_field accessors" do
+    context "when called on a page object" do
+      it "should generate accessor methods" do
+        expect(watir_page_object).to respond_to(:date_of_birth)
+        expect(watir_page_object).to respond_to(:date_of_birth=)
+        expect(watir_page_object).to respond_to(:date_of_birth_element)
+        expect(watir_page_object).to respond_to(:date_of_birth?)
+      end
+
+      it "should call a block on the element method when present" do
+        expect(block_page_object.date_of_birth_element).to eql "date_field"
+      end
+    end
+
+    it "should get the date from the date field element" do
+      expect(watir_browser).to receive(:date_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:value).and_return('2019-12-22')
+      expect(watir_page_object.date_of_birth).to eql '2019-12-22'
+    end
+
+    it "should set some date on a date field element" do
+      expect(watir_browser).to receive(:date_field).and_return(watir_browser)
+      expect(watir_browser).to receive(:set).with('2019-12-22')
+      watir_page_object.date_of_birth = '2019-12-22'
+    end
+
+    it "should retrieve a date field element" do
+      expect(watir_browser).to receive(:date_field).and_return(watir_browser)
+      element = watir_page_object.date_of_birth_element
+      expect(element).to be_instance_of PageObject::Elements::DateField
     end
   end
 


### PR DESCRIPTION
Adds the date_field accessor to interact with inputs of type "date".

Note that this requires increasing the Watir version to 6.10.3, which is when Watir introduced the Element:DateField class.