### PR TITLE
method_missing should only delegate available methods

### DIFF
--- a/lib/page-object.rb
+++ b/lib/page-object.rb
@@ -46,7 +46,11 @@ module PageObject
   include PagePopulator
 
   def method_missing(method, *args, &block)
-    @root_element.send(method, *args, &block)
+    if @root_element.respond_to?(method)
+      @root_element.send(method, *args, &block)
+    else
+      super
+    end
   end
 
   def respond_to_missing?(method, include_all = false)

--- a/lib/page-object/elements/element.rb
+++ b/lib/page-object/elements/element.rb
@@ -175,9 +175,12 @@ module PageObject
 
       # @private
       # delegate calls to driver element
-      def method_missing(*args, &block)
-        m = args.shift
-        element.send m, *args, &block
+      def method_missing(method, *args, &block)
+        if element.respond_to?(method)
+          element.send(method, *args, &block)
+        else
+          super
+        end
       end
 
       def respond_to_missing?(m,*args)


### PR DESCRIPTION
When a method does not exist, we get the errors:

~~~~~~~~
     NoMethodError:
       undefined method `asdfasdfad' for #<Watir::Browser:0x060d06b0>
     # scratch_page_object.rb:35:in `block (2 levels) in <main>'

     NoMethodError:
       undefined method `asdfdsafasdf' for #<Watir::Div: located: false; {:id=>"asdf", :tag_name=>"div"}>
     # scratch_page_object.rb:43:in `block (2 levels) in <main>'
~~~~~~~~

The underlying Watir objects should be transparent. We should only delegate methods that exist - ie the error should be:

~~~~~~~~
     NoMethodError:
       undefined method `asdfasdfad' for #<MyPage:0x06074a78>
     # ./page-object/lib/page-object.rb:52:in `method_missing'
     # scratch_page_object.rb:35:in `block (2 levels) in <main>'

     NoMethodError:
       undefined method `asdfdsafasdf' for #<PageObject::Elements::Div:0x06408a50>
     # ./page-object/lib/page-object/elements/element.rb:182:in `method_missing'
     # scratch_page_object.rb:43:in `block (2 levels) in <main>'
~~~~~~~~