### PR TITLE
Adding Angular support

### DIFF
--- a/lib/page-object/javascript/angular.rb
+++ b/lib/page-object/javascript/angular.rb
@@ -1,0 +1,14 @@
+module PageObject
+  module Javascript
+
+    module Angular
+      #
+      # return the number of pending ajax requests
+      #
+      def self.pending_requests
+        'return getAllAngularTestabilities().filter(x => !x.isStable()).length;'
+      end
+    end
+
+  end
+end

--- a/lib/page-object/javascript_framework_facade.rb
+++ b/lib/page-object/javascript_framework_facade.rb
@@ -2,6 +2,7 @@ require 'page-object/javascript/jquery'
 require 'page-object/javascript/prototype'
 require 'page-object/javascript/yui'
 require 'page-object/javascript/angularjs'
+require 'page-object/javascript/angular'
 
 
 module PageObject
@@ -21,7 +22,7 @@ module PageObject
       # Set the framework to use.
       #
       # @param[Symbol] the framework to use.  :jquery, :prototype, :yui,
-      # and :angularjs are supported
+      # :angularjs, and :angular are supported
       #
       def framework=(framework)
         initialize_script_builder unless @builder
@@ -64,7 +65,8 @@ module PageObject
           :jquery => ::PageObject::Javascript::JQuery,
           :prototype => ::PageObject::Javascript::Prototype,
           :yui => ::PageObject::Javascript::YUI,
-          :angularjs => ::PageObject::Javascript::AngularJS
+          :angularjs => ::PageObject::Javascript::AngularJS,
+          :angular => ::PageObject::Javascript::Angular
         }
       end
 


### PR DESCRIPTION
Angular 2+ introduced Testabilities. There is no longer a way to get the pending requests, but we can find the number of stable zones.

This should address Issue #450.