### PR TITLE
Fixes bug with in_iframe(visible: true)

### DIFF
--- a/features/frames.feature
+++ b/features/frames.feature
@@ -16,6 +16,11 @@ Feature: Handling frames
 
   Scenario: Accessing elements within the frame using multiple identifiers
     Given I am on the iframe elements page
+    When I type "page-object" into the text field for frame 2 using "visible_true"
+    Then I should verify "page-object" is in the text field for frame 2 using "visible_true"
+
+  Scenario: Accessing elements within the frame using visible: true identifier
+    Given I am on the iframe elements page
     When I type "page-object" into the text field for frame 2 using "multiple identifiers"
     Then I should verify "page-object" is in the text field for frame 2 using "multiple identifiers"
 

--- a/features/step_definitions/frames_steps.rb
+++ b/features/step_definitions/frames_steps.rb
@@ -58,6 +58,10 @@ class IFramePage
   in_iframe(:class => 'iframe', :name => 'frame2') do |frame|
     text_field(:text_field_2_multiple_identifiers, :name => 'recieverElement', :frame => frame)
   end
+
+  in_iframe(:class => 'iframe', :name => 'frame2', visible: true) do |frame|
+    text_field(:text_field_2_visible_true, :name => 'recieverElement', :frame => frame)
+  end
 end
 
 

--- a/lib/page-object/platforms/watir/page_object.rb
+++ b/lib/page-object/platforms/watir/page_object.rb
@@ -1113,7 +1113,7 @@ module PageObject
             identifier = frame.values.first.map do |key, value|
               if value.is_a?(Regexp)
                 ":#{key} => #{value.inspect}"
-              elsif value.is_a? Integer
+              elsif value.is_a?(Integer) || value.is_a?(TrueClass) || value.is_a?(FalseClass)
                 ":#{key} => #{value}"
               else
                 ":#{key} => '#{value}'"


### PR DESCRIPTION
Fixes bug where in_iframe(visible: true) blows up because true gets converted to a string, but must stay in TrueClass