### PR TITLE
Update to Yard documentation

### DIFF
--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -31,12 +31,13 @@ module PageObject
     # Specify the url for the page.  A call to this method will generate a
     # 'goto' method to take you to the page and a 'page_url_value' method to return the evaluated url value
     #
-    # @param url [Symbol] the symbolized name of a method that returns a valid url string
-    # @param url [String] the url for the page. The url string will be passed through ERB
-    #
-    # @example page_url('www.google.com')
-    # @example page_url('<%= @params[:url] >')
-    # @example page_url(:example_method)
+    # @overload page_url(url)
+    #   @param url [Symbol] the symbolized name of a method that returns a valid url string
+    #   @example page_url('www.google.com')
+    #   @example page_url('<%= @params[:url] >')
+    # @overload page_url(url)
+    #   @param url [String] the url for the page. The url string will be passed through ERB
+    #   @example page_url(:example_method)
     def page_url(url)
       define_method("goto") do
         platform.navigate_to self.page_url_value
@@ -47,7 +48,7 @@ module PageObject
         erb = ERB.new(%Q{#{lookup}})
         merged_params = self.class.instance_variable_get("@merged_params")
         params = merged_params ? merged_params : self.class.params
-        erb.result
+        erb.result(binding)
       end
     end
     alias_method :direct_url, :page_url
@@ -101,7 +102,7 @@ module PageObject
     #
     # Creates a method that provides a way to initialize a page based upon an expected element.
     # This is useful for pages that load dynamic content.
-    # @param name [Symbol] the name given to the element in the declaration
+    # @param name[Symbol, String] the name given to the element in the declaration
     # @param timeout [Integer] The default value is retrieved frm PageObject.default_element_wait
     #   which defaults to 5 seconds and can be set to another value
     # @return [boolean]
@@ -119,10 +120,10 @@ module PageObject
     #
     # Creates a method that provides a way to initialize a page based upon an expected element to become visible.
     # This is useful for pages that load dynamic content and might have hidden elements that are not shown.
-    # @param element_name [Symbol] the name given to the element in the declaration
+    # @param element_name [Symbol, String] the name given to the element in the declaration
     # @param timeout [Integer] The default value is retrieved frm PageObject.default_element_wait
     #   which defaults to 5 seconds and can be set to another value
-    # @param [Boolean] also check that element to be visible if set to true
+    # @param check_visible [Boolean] also check that element to be visible if set to true
     # @return [Boolean]
     #
     # @example Specify a text box named :address expected on the page within 10 seconds
@@ -1139,8 +1140,8 @@ module PageObject
     #     element(:title, :header, :id => 'title')
     #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    #   @param name [Symbol] the name used for the generated methods
-    #   @param name [Symbol] the name of the tag for the element
+    #   @param name[Symbol, String] the name used for the generated methods
+    #   @param tag [Symbol, String] the name of the tag for the element
     #   @param identifier [Hash] how we find an element.
     # @overload element(name, identifier)
     #   @example
@@ -1148,13 +1149,7 @@ module PageObject
     #     # will generate 'title', 'title_element', and 'title?' methods
     #
     #   @param name [Symbol, String] the name used for the generated methods
-    #   @param name [Symbol, String] the name of the tag for the element
     #   @param identifier [Hash] how we find an element.
-    # @overload element(name, tag, &block)
-    #   @param name [String, Symbol] the name for the methods to be generated
-    #   @param tag [String, Symbol] the tag name of the desired element
-    #   @yield block to return an element
-    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     # @overload element(name, &block)
     #   @param name [String, Symbol] the name for the methods to be generated
     #   @yield block to return an element

--- a/lib/page-object/accessors.rb
+++ b/lib/page-object/accessors.rb
@@ -29,11 +29,14 @@ module PageObject
 
     #
     # Specify the url for the page.  A call to this method will generate a
-    # 'goto' method to take you to the page.
+    # 'goto' method to take you to the page and a 'page_url_value' method to return the evaluated url value
     #
-    # @param [String] the url for the page.
-    # @param [Symbol] a method name to call to get the url
+    # @param url [Symbol] the symbolized name of a method that returns a valid url string
+    # @param url [String] the url for the page. The url string will be passed through ERB
     #
+    # @example page_url('www.google.com')
+    # @example page_url('<%= @params[:url] >')
+    # @example page_url(:example_method)
     def page_url(url)
       define_method("goto") do
         platform.navigate_to self.page_url_value
@@ -44,7 +47,7 @@ module PageObject
         erb = ERB.new(%Q{#{lookup}})
         merged_params = self.class.instance_variable_get("@merged_params")
         params = merged_params ? merged_params : self.class.params
-        erb.result(binding)
+        erb.result
       end
     end
     alias_method :direct_url, :page_url
@@ -54,7 +57,7 @@ module PageObject
     # @param [String] expected_title the literal expected title for the page
     # @param [Regexp] expected_title the expected title pattern for the page
     # @param [optional, Integer] timeout default value is nil - do not wait
-    # @return [boolean]
+    # @return [TrueClass] on success
     # @raise An exception if expected_title does not match actual title
     #
     # @example Specify 'Google' as the expected title of a page
@@ -79,7 +82,7 @@ module PageObject
     # Creates a method that compares the expected_title of a page against the actual.
     # @param [String] expected_title the literal expected title for the page
     # @param [Regexp] expected_title the expected title pattern for the page
-    # @return [boolean]
+    # @return [TrueClass] on success
     # @raise An exception if expected_title does not match actual title
     #
     # @example Specify 'Google' as the expected title of a page
@@ -98,8 +101,9 @@ module PageObject
     #
     # Creates a method that provides a way to initialize a page based upon an expected element.
     # This is useful for pages that load dynamic content.
-    # @param [Symbol] the name given to the element in the declaration
-    # @param [optional, Integer] timeout default value is 5 seconds
+    # @param name [Symbol] the name given to the element in the declaration
+    # @param timeout [Integer] The default value is retrieved frm PageObject.default_element_wait
+    #   which defaults to 5 seconds and can be set to another value
     # @return [boolean]
     #
     # @example Specify a text box named :address expected on the page within 10 seconds
@@ -115,10 +119,11 @@ module PageObject
     #
     # Creates a method that provides a way to initialize a page based upon an expected element to become visible.
     # This is useful for pages that load dynamic content and might have hidden elements that are not shown.
-    # @param [Symbol] the name given to the element in the declaration
-    # @param [optional, Integer] timeout default value is 5 seconds
-    # @param [optional, boolean] also check that element to be visible if set to true
-    # @return [boolean]
+    # @param element_name [Symbol] the name given to the element in the declaration
+    # @param timeout [Integer] The default value is retrieved frm PageObject.default_element_wait
+    #   which defaults to 5 seconds and can be set to another value
+    # @param [Boolean] also check that element to be visible if set to true
+    # @return [Boolean]
     #
     # @example Specify a text box named :address expected on the page within 10 seconds
     #   expected_element_visible(:address, 10)
@@ -132,22 +137,21 @@ module PageObject
     end
 
     #
-    # Identify an element as existing within a frame .  A frame parameter
-    # is passed to the block and must be passed to the other calls to PageObject.
-    # You can nest calls to in_frame by passing the frame to the next level.
+    # Identifies an iframe and yields to a block wherein the elements contained in the frame are defined
+    # elements created within the frame will automatically be searched for within the frame
     #
-    # @example
+    # @example a frame is defined and an element defined within the frame. When the page object responds to a call for first_name it will know to locate the element within the frame
     #   in_frame(:id => 'frame_id') do |frame|
     #     text_field(:first_name, :id => 'fname', :frame => frame)
     #   end
     #
-    # @param [Hash] identifier how we find the frame.  The valid keys are:
+    # @param identifier [Hash] how we find the frame.  The valid keys are:
     #   * :id
     #   * :index
     #   * :name
     #   * :regexp
-    # @param frame passed from a previous call to in_frame.  Used to nest calls
-    # @param block that contains the calls to elements that exist inside the frame.
+    # @yieldparam frame passed from a previous call to in_frame.  Used to nest calls
+    # @yield block that contains the calls to elements that exist inside the frame.
     #
     def in_frame(identifier, frame=nil, &block)
       frame = frame.nil? ? [] : frame.dup
@@ -165,13 +169,13 @@ module PageObject
     #     text_field(:first_name, :id => 'fname', :frame => frame)
     #   end
     #
-    # @param [Hash] identifier how we find the frame.  The valid keys are:
+    # @param identifier [Hash] how we find the frame.  The valid keys are:
     #   * :id
     #   * :index
     #   * :name
     #   * :regexp
-    # @param frame passed from a previous call to in_iframe.  Used to nest calls
-    # @param block that contains the calls to elements that exist inside the iframe.
+    # @yieldparam frame passed from a previous call to in_iframe.  Used to nest calls
+    # @yield block that contains the calls to elements that exist inside the iframe.
     #
     def in_iframe(identifier, frame=nil, &block)
       frame = frame.nil? ? [] : frame.dup
@@ -183,15 +187,20 @@ module PageObject
     # adds four methods to the page object - one to set text in a text field,
     # another to retrieve text from a text field, another to return the text
     # field element, another to check the text field's existence.
-    #
-    # @example
-    #   text_field(:first_name, :id => "first_name")
-    #   # will generate 'first_name', 'first_name=', 'first_name_element',
-    #   # 'first_name?' methods
-    #
-    # @param [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a text field.
-    # @param optional block to be invoked when element method is called
+    # @note generates $1, $1?, $1=, $1_element methods
+    # @overload text_field(name, identifier)
+    #   Identifies the element based on the element identifier
+    #   @param [String, Symbol] the name used for the generated methods
+    #   @param identifier [Hash] how we find a text field.
+    #   @example
+    #     text_field(:first_name, :id => "first_name")
+    # @overload text_field(name, &block)
+    #   Uses uses the element returned by the block instead of the identifier to find the element
+    #   @param name [String, Symbol]
+    #   @yield block to be invoked when element method is called
+    #   @yieldreturn [Watir::Element, PageObject::Elements::Element]
+    #   @example
+    #     text_field(:first_name) { @browser.h1(index: 1) }
     #
     def text_field(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'text_field_for', &block)
@@ -210,15 +219,25 @@ module PageObject
     # another to retrieve value from a date field, another to return the date
     # field element, another to check the date field's existence.
     #
-    # @example
-    #   date_field(:date_of_birth, :id => "date_of_birth")
-    #   # will generate 'date_of_birth', 'date_of_birth=', 'date_of_birth_element',
-    #   # 'date_of_birth?' methods
+    # @overload date_field(name, identifier)
     #
-    # @param [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a date field.
-    # @param optional block to be invoked when element method is called
+    #   @example
+    #     date_field(:date_of_birth, :id => "date_of_birth")
+    #     # will generate 'date_of_birth', 'date_of_birth=', 'date_of_birth_element',
+    #     # 'date_of_birth?' methods
     #
+    #   @param name [String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a date field.
+    #
+    # @overload date_field(name, &block)
+    #   @example
+    #     date_field(:date_of_birth) { @browser.input(index: 3) }
+    #     # will generate 'date_of_birth', 'date_of_birth=', 'date_of_birth_element',
+    #     # 'date_of_birth?' methods
+    #
+    #   @param name [String] the name used for the generated methods
+    #   @yield block used in lieu of identifier
+    #   @yieldreturn [Watir::Element, PageObject::Elements::Element]
     def date_field(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'date_field_for', &block)
       define_method(name) do
@@ -236,13 +255,17 @@ module PageObject
     # another to retrieve the hidden field element, and another to check the hidden
     # field's existence.
     #
-    # @example
-    #   hidden_field(:user_id, :id => "user_identity")
-    #   # will generate 'user_id', 'user_id_element' and 'user_id?' methods
+    # @overload hidden_field(name, identifier)
+    #   @example
+    #     hidden_field(:user_id, :id => "user_identity")
+    #     # will generate 'user_id', 'user_id_element' and 'user_id?' methods
     #
-    # @param [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a hidden field.
-    # @param optional block to be invoked when element method is called
+    #   @param [String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a hidden field.
+    # @overload hidden_field(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def hidden_field(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'hidden_field_for', &block)
@@ -258,14 +281,18 @@ module PageObject
     # another to retrieve text from a text area, another to return the text
     # area element, and another to check the text area's existence.
     #
-    # @example
-    #   text_area(:address, :id => "address")
-    #   # will generate 'address', 'address=', 'address_element',
-    #   # 'address?' methods
+    # @overload text_area(name, identifier)
+    #   @example
+    #     text_area(:address, :id => "address")
+    #     # will generate 'address', 'address=', 'address_element',
+    #     # 'address?' methods
     #
-    # @param [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a text area.
-    # @param optional block to be invoked when element method is called
+    #   @param [String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a text area.
+    # @overload text_area(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def text_area(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'text_area_for', &block)
@@ -287,13 +314,17 @@ module PageObject
     # drop down's existence and another to get all the available options
     # to select from.
     #
-    # @example
-    #   select_list(:state, :id => "state")
-    #   # will generate 'state', 'state=', 'state_element', 'state?', "state_options" methods
+    # @overload select_list(name, identifier)
+    #   @example
+    #     select_list(:state, :id => "state")
+    #     # will generate 'state', 'state=', 'state_element', 'state?', "state_options" methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a select list.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a select list.
+    # @overload select_list(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def select_list(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'select_list_for', &block)
@@ -317,13 +348,17 @@ module PageObject
     # to return a PageObject::Elements::Link object representing
     # the link, and another that checks the link's existence.
     #
-    # @example
-    #   link(:add_to_cart, :text => "Add to Cart")
-    #   # will generate 'add_to_cart', 'add_to_cart_element', and 'add_to_cart?' methods
+    # @overload link(name, identifier)
+    #   @example
+    #     link(:add_to_cart, :text => "Add to Cart")
+    #     # will generate 'add_to_cart', 'add_to_cart_element', and 'add_to_cart?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a link.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a link.
+    # @overload link(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def link(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'link_for', &block)
@@ -340,14 +375,18 @@ module PageObject
     # a PageObject::Elements::CheckBox object representing the checkbox, and
     # a final method to check the checkbox's existence.
     #
-    # @example
-    #   checkbox(:active, :name => "is_active")
-    #   # will generate 'check_active', 'uncheck_active', 'active_checked?',
-    #   # 'active_element', and 'active?' methods
+    # @overload checkbox(name, identifier)
+    #   @example
+    #     checkbox(:active, :name => "is_active")
+    #     # will generate 'check_active', 'uncheck_active', 'active_checked?',
+    #     # 'active_element', and 'active?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a checkbox.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a checkbox.
+    # @overload checkbox(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def checkbox(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'checkbox_for', &block)
@@ -371,14 +410,18 @@ module PageObject
     # object representing the radio button element, and another to check
     # the radio button's existence.
     #
-    # @example
-    #   radio_button(:north, :id => "north")
-    #   # will generate 'select_north', 'north_selected?',
-    #   # 'north_element', and 'north?' methods
+    # @overload radio_button(name, identifier)
+    #   @example
+    #     radio_button(:north, :id => "north")
+    #     # will generate 'select_north', 'north_selected?',
+    #     # 'north_element', and 'north?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a radio button.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a radio button.
+    # @overload radio_button(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def radio_button(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'radio_button_for', &block)
@@ -408,7 +451,7 @@ module PageObject
     # will generate 'select_color', 'color_values', 'color_selected?',
     # 'color_elements', and 'color?' methods
     #
-    # @param [Symbol] the name used for the generated methods
+    # @param name [Symbol, String] the name used for the generated methods
     # @param [Hash] shared identifier for the radio button group. Typically, a 'name' attribute.
     # The valid keys are:
     # * :name
@@ -447,13 +490,17 @@ module PageObject
     # adds three methods - one to click a button, another to
     # return the button element, and another to check the button's existence.
     #
-    # @example
-    #   button(:purchase, :id => 'purchase')
-    #   # will generate 'purchase', 'purchase_element', and 'purchase?' methods
+    # @overload button(name, identifier)
+    #   @example
+    #     button(:purchase, :id => 'purchase')
+    #     # will generate 'purchase', 'purchase_element', and 'purchase?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a button.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a button.
+    # @overload button(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def button(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'button_for', &block)
@@ -467,13 +514,17 @@ module PageObject
     # adds three methods - one to retrieve the text from a div,
     # another to return the div element, and another to check the div's existence.
     #
-    # @example
-    #   div(:message, :id => 'message')
-    #   # will generate 'message', 'message_element', and 'message?' methods
+    # @overload div(name, identifier)
+    #   @example
+    #     div(:message, :id => 'message')
+    #     # will generate 'message', 'message_element', and 'message?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a div.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a div.
+    # @overload div(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def div(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'div_for', &block)
@@ -487,13 +538,17 @@ module PageObject
     # adds three methods - one to retrieve the text from a span,
     # another to return the span element, and another to check the span's existence.
     #
-    # @example
+    # @overload span(name, identifier)
+    #   @example
     #   span(:alert, :id => 'alert')
     #   # will generate 'alert', 'alert_element', and 'alert?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a span.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a span.
+    # @overload span(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def span(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'span_for', &block)
@@ -508,13 +563,17 @@ module PageObject
     # to  retrieve the table element, and another to
     # check the table's existence.
     #
-    # @example
-    #   table(:cart, :id => 'shopping_cart')
-    #   # will generate a 'cart', 'cart_element' and 'cart?' method
+    # @overload table(name, identifier)
+    #   @example
+    #     table(:cart, :id => 'shopping_cart')
+    #     # will generate a 'cart', 'cart_element' and 'cart?' method
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a table.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a table.
+    # @overload table(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def table(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'table_for', &block)
@@ -529,13 +588,17 @@ module PageObject
     # another to return the table cell element, and another to check the cell's
     # existence.
     #
-    # @example
-    #   cell(:total, :id => 'total_cell')
-    #   # will generate 'total', 'total_element', and 'total?' methods
+    # @overload cell(name, identifier)
+    #   @example
+    #     cell(:total, :id => 'total_cell')
+    #     # will generate 'total', 'total_element', and 'total?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a cell.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a cell.
+    # @overload cell(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def cell(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'cell_for', &block)
@@ -552,13 +615,17 @@ module PageObject
     # another to return the table row element, and another to check the row's
     # existence.
     #
-    # @example
-    #   row(:sums, :id => 'sum_row')
-    #   # will generate 'sums', 'sums_element', and 'sums?' methods
+    # @overload row(name, identifier)
+    #   @example
+    #     row(:sums, :id => 'sum_row')
+    #     # will generate 'sums', 'sums_element', and 'sums?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a cell.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a cell.
+    # @overload row(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def row(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'row_for', &block)
@@ -573,13 +640,17 @@ module PageObject
     # check the load status of the image, and another to check the
     # image's existence.
     #
-    # @example
-    #   image(:logo, :id => 'logo')
-    #   # will generate 'logo_element', 'logo_loaded?', and 'logo?' methods
+    # @overload image(name, identifier)
+    #   @example
+    #     image(:logo, :id => 'logo')
+    #     # will generate 'logo_element', 'logo_loaded?', and 'logo?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an image.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find an image.
+    # @overload image(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def image(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'image_for', &block)
@@ -594,13 +665,17 @@ module PageObject
     # adds two methods - one to retrieve the form element, and another to
     # check the form's existence.
     #
-    # @example
-    #   form(:login, :id => 'login')
-    #   # will generate 'login_element' and 'login?' methods
+    # @overload form(name, identifier)
+    #   @example
+    #     form(:login, :id => 'login')
+    #     # will generate 'login_element' and 'login?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a form.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a form.
+    # @overload form(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def form(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'form_for', &block)
@@ -611,13 +686,17 @@ module PageObject
     # another to return the list item element, and another to check the list item's
     # existence.
     #
-    # @example
-    #   list_item(:item_one, :id => 'one')
-    #   # will generate 'item_one', 'item_one_element', and 'item_one?' methods
+    # @overload list_item(name, identifier)
+    #   @example
+    #     list_item(:item_one, :id => 'one')
+    #     # will generate 'item_one', 'item_one_element', and 'item_one?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a list item.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a list item.
+    # @overload list_item(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def list_item(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'list_item_for', &block)
@@ -633,13 +712,17 @@ module PageObject
     # list, one to retrieve the unordered list element, and another to
     # check it's existence.
     #
-    # @example
-    #   unordered_list(:menu, :id => 'main_menu')
-    #   # will generate 'menu', 'menu_element' and 'menu?' methods
+    # @overload unordered_list(name, identifier)
+    #   @example
+    #     unordered_list(:menu, :id => 'main_menu')
+    #     # will generate 'menu', 'menu_element' and 'menu?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an unordered list.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find an unordered list.
+    # @overload unordered_list(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def unordered_list(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'unordered_list_for', &block)
@@ -655,13 +738,17 @@ module PageObject
     # list, one to retrieve the ordered list element, and another to
     # test it's existence.
     #
-    # @example
-    #   ordered_list(:top_five, :id => 'top')
-    #   # will generate 'top_five', 'top_five_element' and 'top_five?' methods
+    # @overload ordered_list(name, identifier)
+    #   @example
+    #     ordered_list(:top_five, :id => 'top')
+    #     # will generate 'top_five', 'top_five_element' and 'top_five?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an ordered list.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find an ordered list.
+    # @overload ordered_list(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def ordered_list(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'ordered_list_for', &block)
@@ -676,14 +763,19 @@ module PageObject
     # adds three methods - one to retrieve the text of a h1 element, another to
     # retrieve a h1 element, and another to check for it's existence.
     #
-    # @example
-    #   h1(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload(name, identifier)
+    #   @example
+    #     h1(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H1.  You can use a multiple parameters
-    #   by combining of any of the following except xpath.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a H1.  You can use a multiple parameters
+    #     by combining of any of the following except xpath.
+
+    # @overload h1(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element]
     #
     def h1(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier,'h1_for', &block)
@@ -697,13 +789,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a h2 element, another
     # to retrieve a h2 element, and another to check for it's existence.
     #
-    # @example
-    #   h2(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload h2(name, identifier)
+    #   @example
+    #     h2(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H2.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a H2.
+    # @overload h2(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def h2(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'h2_for', &block)
@@ -717,13 +813,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a h3 element,
     # another to return a h3 element, and another to check for it's existence.
     #
-    # @example
-    #   h3(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload h3(name, identifier)
+    #   @example
+    #     h3(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H3.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a H3.
+    # @overload h3(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element]
     #
     def h3(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'h3_for', &block)
@@ -737,13 +837,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a h4 element,
     # another to return a h4 element, and another to check for it's existence.
     #
-    # @example
-    #   h4(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload h4(name, identifier)
+    #   @example
+    #     h4(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H4.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a H4.
+    # @overload h4(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def h4(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'h4_for', &block)
@@ -757,13 +861,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a h5 element,
     # another to return a h5 element, and another to check for it's existence.
     #
-    # @example
-    #   h5(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload h5(name, identifier)
+    #   @example
+    #     h5(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H5.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a H5.
+    # @overload h5(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def h5(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'h5_for', &block)
@@ -777,13 +885,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a h6 element,
     # another to return a h6 element, and another to check for it's existence.
     #
-    # @example
-    #   h6(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload h6(name, identifier)
+    #   @example
+    #     h6(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a H6.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a H6.
+    # @overload h6(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def h6(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'h6_for', &block)
@@ -797,13 +909,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a paragraph, another
     # to retrieve a paragraph element, and another to check the paragraph's existence.
     #
-    # @example
-    #   paragraph(:title, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload paragraph(name, identifier)
+    #   @example
+    #     paragraph(:title, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a paragraph.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a paragraph.
+    # @overload paragraph(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def paragraph(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'paragraph_for', &block)
@@ -818,13 +934,17 @@ module PageObject
     # adds three methods - one to set the file for a file field, another to retrieve
     # the file field element, and another to check it's existence.
     #
-    # @example
-    #   file_field(:the_file, :id => 'file_to_upload')
-    #   # will generate 'the_file=', 'the_file_element', and 'the_file?' methods
+    # @overload file_field(name, identifier)
+    #   @example
+    #     file_field(:the_file, :id => 'file_to_upload')
+    #     # will generate 'the_file=', 'the_file_element', and 'the_file?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a file_field.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a file_field.
+    # @overload file_field(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def file_field(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'file_field_for', &block)
@@ -838,13 +958,17 @@ module PageObject
     # adds three methods - one to retrieve the text from a label,
     # another to return the label element, and another to check the label's existence.
     #
-    # @example
-    #   label(:message, :id => 'message')
-    #   # will generate 'message', 'message_element', and 'message?' methods
+    # @overload label(name, identifier)
+    #   @example
+    #     label(:message, :id => 'message')
+    #     # will generate 'message', 'message_element', and 'message?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a label.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a label.
+    # @overload label(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def label(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'label_for', &block)
@@ -857,14 +981,16 @@ module PageObject
     #
     # adds three methods - one to click the area,
     # another to return the area element, and another to check the area's existence.
-    #
-    # @example
-    #   area(:message, :id => 'message')
-    #   # will generate 'message', 'message_element', and 'message?' methods
-    #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an area.
-    # @param optional block to be invoked when element method is called
+    # @overload area(name, identifier)
+    #   @example
+    #     area(:message, :id => 'message')
+    #     # will generate 'message', 'message_element', and 'message?' methods
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find an area.
+    # @overload area(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def area(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'area_for', &block)
@@ -878,13 +1004,17 @@ module PageObject
     # adds two methods - one to return the canvas element and another to check
     # the canvas's existence.
     #
-    # @example
-    #   canvas(:my_canvas, :id => 'canvas_id')
-    #   # will generate 'my_canvas_element' and 'my_canvas?' methods
+    # @overload canvas(name, identifier)
+    #   @example
+    #     canvas(:my_canvas, :id => 'canvas_id')
+    #     # will generate 'my_canvas_element' and 'my_canvas?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a canvas.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a canvas.
+    # @overload canvas(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def canvas(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'canvas_for', &block)
@@ -894,13 +1024,17 @@ module PageObject
     # adds two methods - one to return the audio element and another to check
     # the audio's existence.
     #
-    # @example
-    #   audio(:acdc, :id => 'audio_id')
-    #   # will generate 'acdc_element' and 'acdc?' methods
+    # @overload audio(name, identifier)
+    #   @example
+    #     audio(:acdc, :id => 'audio_id')
+    #     # will generate 'acdc_element' and 'acdc?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find an audio element.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find an audio element.
+    # @overload audio(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def audio(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'audio_for', &block)
@@ -910,13 +1044,17 @@ module PageObject
     # adds two methods - one to return the video element and another to check
     # the video's existence.
     #
-    # @example
-    #   video(:movie, :id => 'video_id')
-    #   # will generate 'movie_element' and 'movie?' methods
+    # @overload video(name, identifier)
+    #   @example
+    #     video(:movie, :id => 'video_id')
+    #     # will generate 'movie_element' and 'movie?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a video element.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a video element.
+    # @overload video(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def video(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'video_for', &block)
@@ -926,13 +1064,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a b element, another to
     # retrieve a b element, and another to check for it's existence.
     #
-    # @example
-    #   b(:bold, :id => 'title')
-    #   # will generate 'bold', 'bold_element', and 'bold?' methods
+    # @overload b(name, identifier)
+    #   @example
+    #     b(:bold, :id => 'title')
+    #     # will generate 'bold', 'bold_element', and 'bold?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a b.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a b.
+    # @overload b(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def b(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier,'b_for', &block)
@@ -946,13 +1088,17 @@ module PageObject
     # adds three methods - one to retrieve the text of a i element, another to
     # retrieve a i element, and another to check for it's existence.
     #
-    # @example
-    #   i(:italic, :id => 'title')
-    #   # will generate 'italic', 'italic_element', and 'italic?' methods
+    # @overload i(name, identifier)
+    #   @example
+    #     i(:italic, :id => 'title')
+    #     # will generate 'italic', 'italic_element', and 'italic?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a i.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a i.
+    # @overload i(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def i(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier,'i_for', &block)
@@ -967,13 +1113,17 @@ module PageObject
     # adds two methods - one to retrieve a svg, and another to check
     # the svg's existence.
     #
-    # @example
-    #   svg(:circle, :id => 'circle')
-    #   # will generate 'circle_element', and 'circle?' methods
+    # @overload svg(name, identifier)
+    #   @example
+    #     svg(:circle, :id => 'circle')
+    #     # will generate 'circle_element', and 'circle?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Hash] identifier how we find a svg.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find a svg.
+    # @overload svg(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def svg(name, identifier={:index => 0}, &block)
       standard_methods(name, identifier, 'svg_for', &block)
@@ -984,14 +1134,31 @@ module PageObject
     # adds three methods - one to retrieve the text of an element, another
     # to retrieve an element, and another to check the element's existence.
     #
-    # @example
-    #   element(:title, :header, :id => 'title')
-    #   # will generate 'title', 'title_element', and 'title?' methods
+    # @overload element(name, tag, identifier)
+    #   @example
+    #     element(:title, :header, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Symbol] the name of the tag for the element
-    # @param [Hash] identifier how we find an element.
-    # @param optional block to be invoked when element method is called
+    #   @param name [Symbol] the name used for the generated methods
+    #   @param name [Symbol] the name of the tag for the element
+    #   @param identifier [Hash] how we find an element.
+    # @overload element(name, identifier)
+    #   @example
+    #     element(:title, :header, :id => 'title')
+    #     # will generate 'title', 'title_element', and 'title?' methods
+    #
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param name [Symbol, String] the name of the tag for the element
+    #   @param identifier [Hash] how we find an element.
+    # @overload element(name, tag, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @param tag [String, Symbol] the tag name of the desired element
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
+    # @overload element(name, &block)
+    #   @param name [String, Symbol] the name for the methods to be generated
+    #   @yield block to return an element
+    #   @yieldreturn [PageObject::Elements::Element, Watir::Element] desired element
     #
     def element(name, tag=:element, identifier={ :index => 0 }, &block)
       #
@@ -1045,14 +1212,26 @@ module PageObject
     # adds a method to return a collection of generic Element objects
     # for a specific tag.
     #
-    # @example
-    #   elements(:title, :header, :id => 'title')
-    #   # will generate ''title_elements'
-    #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Symbol] the name of the tag for the element
-    # @param [Hash] identifier how we find an element.
-    # @param optional block to be invoked when element method is called
+    # @overload elements(name, &block)
+    #   @example
+    #     elements(:title) { @browser.elements(tag: h1) }
+    #     # will generate 'title_elements'
+    #   @param name [String, Symbol] the name used fo the generated methods
+    #   @yield block returning a group of elements
+    #   @yieldreturn [Watir::Elements, PageObject::Elements]
+    # @overload elements(name, identifier)
+    #   @example
+    #     elements(:title, :header, :id => 'title')
+    #     # will generate 'title_elements'
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param identifier [Hash] how we find an element.
+    # @overload elements(name, tag, identifier)
+    #   @example
+    #     elements(:title, :header, :id => 'title')
+    #     # will generate 'title_elements'
+    #   @param name [Symbol, String] the name used for the generated methods
+    #   @param tag [Symbol, String] the name of the tag for the element
+    #   @param identifier [Hash] how we find an element.
     #
     def elements(name, tag=:element, identifier={:index => 0}, &block)
       #
@@ -1076,9 +1255,9 @@ module PageObject
     #   page_section(:navigation_bar, NavigationBar, :id => 'nav-bar')
     #   # will generate 'navigation_bar'
     #
-    # @param [Symbol] the name used for the generated methods
+    # @param name [Symbol, String] the name used for the generated methods
     # @param [Class] the class to instantiate for the element
-    # @param [Hash] identifier how we find an element.
+    # @param identifier [Hash] how we find an element.
     #
     def page_section(name, section_class, identifier)
       define_method(name) do
@@ -1093,9 +1272,9 @@ module PageObject
     #   page_sections(:articles, Article, :class => 'article')
     #   # will generate 'articles'
     #
-    # @param [Symbol] the name used for the generated method
+    # @param name [Symbol, String] the name used for the generated method
     # @param [Class] the class to instantiate for each element
-    # @param [Hash] identifier how we find an element.
+    # @param identifier [Hash] how we find an element.
     #
     def page_sections(name, section_class, identifier)
       define_method(name) do
@@ -1113,9 +1292,9 @@ module PageObject
     #   articles(:my_article, :id => 'article_id')
     #   will generate 'my_article_elements'
     #
-    # @param [Symbol] the name used for the generated methods
-    # @param [Symbol] the name of the tag for the element
-    # @param [Hash] identifier how we find an element.
+    # @param name [Symbol, String] the name used for the generated methods
+    # @param tag [Symbol, String] the name of the tag for the element
+    # @param identifier [Hash] how we find an element.
     # @param optional block to be invoked when element method is called
     #
     LocatorGenerator::BASIC_ELEMENTS.each do |tag|
@@ -1158,7 +1337,7 @@ module PageObject
     #   # given names, using the given how and what with 'foo' substituted for the %s.  title[123]
     #   # will do the same, using the integer 123 instead.
     #
-    # @param [Symbol] the name used for the generated method
+    # @param name [Symbol, String] the name used for the generated method
     # @param [Array] definitions an array of definitions to define on the indexed property.  Each
     #   entry in the array should contain two symbols and a hash, corresponding to one of the standard
     #   page_object properties with a single substitution marker in each value in the hash,
@@ -1180,7 +1359,7 @@ module PageObject
     #   # will generate 'first_name_elements'
     #
     # @param [String] the name used for the generated methods
-    # @param [Hash] identifier how we find a text field.  You can use a multiple parameters
+    # @param identifier [Hash] how we find a text field.  You can use a multiple parameters
     #   by combining of any of the following except xpath.  The valid
     #   keys are the same ones supported by the standard methods.
     # @param optional block to be invoked when element method is called


### PR DESCRIPTION
Yard provides an overload annotation for when methods behave differently depending on what parameters are passed. The accessor methods behave entirely differently depending on whether a block is passed to them. I have added the overload annotation to the Yard comments to better document the different handling